### PR TITLE
[BugFix] Disable dismiss on participant list click/touch

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/participantlist/ParticipantListView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/participantlist/ParticipantListView.kt
@@ -150,7 +150,6 @@ internal class ParticipantListView(
             R.color.azure_communication_ui_color_participant_list_mute_mic,
             isMuted
         ) {
-            participantListDrawer.dismiss()
         }
     }
 }


### PR DESCRIPTION
## Purpose
Originally the participant list is dismissed when we are clicking on any items on the participant list. Now we disable this function to make it consistent with iOS side.
impact: participant list view

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code
Join a group/teams call with few participants, open the participant list, then click on the participant list to verify if it is dismissed.