### PR TITLE
[BugFix] Fix compliance banner logic, reset recording stop and transcription stop case

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerViewModel.kt
@@ -90,6 +90,7 @@ internal class BannerViewModel {
         } else if ((recordingState == ComplianceState.STOPPED) &&
             (transcriptionState == ComplianceState.STOPPED)
         ) {
+            resetStoppedStates()
             return BannerInfoType.RECORDING_AND_TRANSCRIPTION_STOPPED
         } else {
             return BannerInfoType.BLANK

--- a/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerViewModelUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerViewModelUnitTest.kt
@@ -1497,7 +1497,7 @@ internal class BannerViewModelUnitTest {
             isTranscribing = false,
         )
         val expectedBannerInfoType: BannerInfoType =
-            BannerInfoType.RECORDING_AND_TRANSCRIPTION_STOPPED
+            BannerInfoType.BLANK
 
         mainCoroutineRule.testDispatcher.runBlockingTest {
             // arrange
@@ -1546,7 +1546,7 @@ internal class BannerViewModelUnitTest {
             isTranscribing = true,
         )
         val expectedBannerInfoType: BannerInfoType =
-            BannerInfoType.RECORDING_STOPPED_STILL_TRANSCRIBING
+            BannerInfoType.TRANSCRIPTION_STARTED
 
         mainCoroutineRule.testDispatcher.runBlockingTest {
             // arrange
@@ -1595,7 +1595,7 @@ internal class BannerViewModelUnitTest {
             isTranscribing = false,
         )
         val expectedBannerInfoType: BannerInfoType =
-            BannerInfoType.TRANSCRIPTION_STOPPED_STILL_RECORDING
+            BannerInfoType.RECORDING_STARTED
 
         mainCoroutineRule.testDispatcher.runBlockingTest {
             // arrange


### PR DESCRIPTION
## Purpose
Previously have misleading message after starting and stopping both recording and transcription, then start transcription again, the resulting message is not very intuitive. And would need to dismiss the banner to reset state
impact: banner view text

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Test recording/transcription banner will display correct message in teams interop meeting when starting/stopping recording/transcription from Teams client