### PR TITLE
[BugFix]Fix Mute/Unmute State in Waiting Lobby

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingViewModel.kt
@@ -94,8 +94,7 @@ internal class CallingViewModel(
         controlBarViewModel.init(
             state.permissionState,
             state.localParticipantState.cameraState,
-            state.localParticipantState.audioState,
-            state.callState,
+            state.localParticipantState.audioState
         )
 
         localParticipantViewModel.init(
@@ -138,8 +137,7 @@ internal class CallingViewModel(
         controlBarViewModel.update(
             state.permissionState,
             state.localParticipantState.cameraState,
-            state.localParticipantState.audioState,
-            state.callState,
+            state.localParticipantState.audioState
         )
 
         localParticipantViewModel.update(

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/controlbar/ControlBarViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/controlbar/ControlBarViewModel.kt
@@ -9,8 +9,6 @@ import com.azure.android.communication.ui.redux.action.LocalParticipantAction
 import com.azure.android.communication.ui.redux.state.AudioDeviceSelectionStatus
 import com.azure.android.communication.ui.redux.state.AudioOperationalStatus
 import com.azure.android.communication.ui.redux.state.AudioState
-import com.azure.android.communication.ui.redux.state.CallingState
-import com.azure.android.communication.ui.redux.state.CallingStatus
 import com.azure.android.communication.ui.redux.state.CameraState
 import com.azure.android.communication.ui.redux.state.PermissionState
 import com.azure.android.communication.ui.redux.state.PermissionStatus
@@ -29,27 +27,25 @@ internal class ControlBarViewModel(
     fun init(
         permissionState: PermissionState,
         cameraState: CameraState,
-        audioState: AudioState,
-        callingState: CallingState,
+        audioState: AudioState
     ) {
         cameraStateFlow =
             MutableStateFlow(CameraModel(permissionState.cameraPermissionState, cameraState))
         audioOperationalStatusStateFlow = MutableStateFlow(audioState.operation)
         audioDeviceSelectionStatusStateFlow = MutableStateFlow(audioState.device)
         shouldEnableMicButtonStateFlow =
-            MutableStateFlow(shouldEnableMicButton(audioState, callingState))
+            MutableStateFlow(shouldEnableMicButton(audioState))
     }
 
     fun update(
         permissionState: PermissionState,
         cameraState: CameraState,
-        audioState: AudioState,
-        callingState: CallingState,
+        audioState: AudioState
     ) {
         cameraStateFlow.value = CameraModel(permissionState.cameraPermissionState, cameraState)
         audioOperationalStatusStateFlow.value = audioState.operation
         audioDeviceSelectionStatusStateFlow.value = audioState.device
-        shouldEnableMicButtonStateFlow.value = shouldEnableMicButton(audioState, callingState)
+        shouldEnableMicButtonStateFlow.value = shouldEnableMicButton(audioState)
     }
 
     fun getAudioOperationalStatusStateFlow(): StateFlow<AudioOperationalStatus> {
@@ -88,8 +84,8 @@ internal class ControlBarViewModel(
         audioDeviceListViewModel.displayAudioDeviceSelectionMenu()
     }
 
-    private fun shouldEnableMicButton(audioState: AudioState, callingState: CallingState): Boolean {
-        return (audioState.operation != AudioOperationalStatus.PENDING && callingState.CallingStatus != CallingStatus.IN_LOBBY)
+    private fun shouldEnableMicButton(audioState: AudioState): Boolean {
+        return (audioState.operation != AudioOperationalStatus.PENDING)
     }
 
     private fun dispatchAction(action: Action) {

--- a/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingViewModelUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingViewModelUnitTest.kt
@@ -65,7 +65,7 @@ internal class CallingViewModelUnitTest {
             }
 
             val mockControlBarViewModel = mock<ControlBarViewModel> {
-                on { update(any(), any(), any(), any()) } doAnswer { }
+                on { update(any(), any(), any()) } doAnswer { }
             }
 
             val mockConfirmLeaveOverlayViewModel = mock<ConfirmLeaveOverlayViewModel> {}
@@ -113,7 +113,7 @@ internal class CallingViewModelUnitTest {
 
             // assert
             verify(mockParticipantGridViewModel, times(0)).update(any(), any())
-            verify(mockControlBarViewModel, times(1)).update(any(), any(), any(), any())
+            verify(mockControlBarViewModel, times(1)).update(any(), any(), any())
             verify(mockLocalParticipantViewModel, times(1)).update(
                 any(), any(), any(), any(), any(), any()
             )
@@ -139,7 +139,7 @@ internal class CallingViewModelUnitTest {
             }
 
             val mockControlBarViewModel = mock<ControlBarViewModel> {
-                on { update(any(), any(), any(), any()) } doAnswer { }
+                on { update(any(), any(), any()) } doAnswer { }
             }
 
             val mockConfirmLeaveOverlayViewModel = mock<ConfirmLeaveOverlayViewModel> {}
@@ -187,7 +187,7 @@ internal class CallingViewModelUnitTest {
 
             // assert
             verify(mockParticipantGridViewModel, times(0)).update(any(), any())
-            verify(mockControlBarViewModel, times(2)).update(any(), any(), any(), any())
+            verify(mockControlBarViewModel, times(2)).update(any(), any(), any())
             verify(mockLocalParticipantViewModel, times(2)).update(
                 any(), any(), any(), any(), any(), any()
             )
@@ -214,7 +214,7 @@ internal class CallingViewModelUnitTest {
             }
 
             val mockControlBarViewModel = mock<ControlBarViewModel> {
-                on { update(any(), any(), any(), any()) } doAnswer { }
+                on { update(any(), any(), any()) } doAnswer { }
             }
 
             val mockConfirmLeaveOverlayViewModel = mock<ConfirmLeaveOverlayViewModel> {}
@@ -269,7 +269,7 @@ internal class CallingViewModelUnitTest {
             verify(mockFloatingHeaderViewModel, times(1)).update(any())
             verify(mockParticipantListViewModel, times(1)).update(any(), any())
             verify(mockBannerViewModel, times(1)).update(any())
-            verify(mockControlBarViewModel, times(2)).update(any(), any(), any(), any())
+            verify(mockControlBarViewModel, times(2)).update(any(), any(), any())
             verify(mockLocalParticipantViewModel, times(2)).update(
                 any(), any(), any(), any(), any(), any()
             )
@@ -295,7 +295,7 @@ internal class CallingViewModelUnitTest {
             }
 
             val mockControlBarViewModel = mock<ControlBarViewModel> {
-                on { update(any(), any(), any(), any()) } doAnswer { }
+                on { update(any(), any(), any()) } doAnswer { }
             }
 
             val mockConfirmLeaveOverlayViewModel = mock<ConfirmLeaveOverlayViewModel> {}
@@ -345,7 +345,7 @@ internal class CallingViewModelUnitTest {
             verify(mockFloatingHeaderViewModel, times(0)).update(any())
             verify(mockParticipantListViewModel, times(0)).update(any(), any())
             verify(mockBannerViewModel, times(0)).update(any())
-            verify(mockControlBarViewModel, times(2)).update(any(), any(), any(), any())
+            verify(mockControlBarViewModel, times(2)).update(any(), any(), any())
             verify(mockLocalParticipantViewModel, times(2)).update(
                 any(), any(), any(), any(), any(), any()
             )

--- a/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/controlbar/ControlBarViewModelUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/controlbar/ControlBarViewModelUnitTest.kt
@@ -11,8 +11,6 @@ import com.azure.android.communication.ui.redux.state.AppReduxState
 import com.azure.android.communication.ui.redux.state.AudioDeviceSelectionStatus
 import com.azure.android.communication.ui.redux.state.AudioOperationalStatus
 import com.azure.android.communication.ui.redux.state.AudioState
-import com.azure.android.communication.ui.redux.state.CallingState
-import com.azure.android.communication.ui.redux.state.CallingStatus
 import com.azure.android.communication.ui.redux.state.CameraDeviceSelectionStatus
 import com.azure.android.communication.ui.redux.state.CameraOperationalStatus
 import com.azure.android.communication.ui.redux.state.CameraState
@@ -99,7 +97,6 @@ internal class ControlBarViewModelUnitTest {
             val permissionState = PermissionState(PermissionStatus.DENIED, PermissionStatus.DENIED)
             val cameraState = CameraState(CameraOperationalStatus.OFF, CameraDeviceSelectionStatus.FRONT, CameraTransmissionStatus.REMOTE)
             val audioDeviceState = AudioDeviceSelectionStatus.RECEIVER_SELECTED
-            val callingState = CallingState(CallingStatus.CONNECTED)
 
             val appStore = mock<AppStore<ReduxState>> { }
             val audioDeviceListViewModel = mock<AudioDeviceListViewModel>()
@@ -107,8 +104,7 @@ internal class ControlBarViewModelUnitTest {
             callingViewModel.init(
                 permissionState,
                 cameraState,
-                AudioState(AudioOperationalStatus.OFF, audioDeviceState),
-                callingState,
+                AudioState(AudioOperationalStatus.OFF, audioDeviceState)
             )
 
             val expectedAudioOperationalStatus1 = AudioOperationalStatus.ON
@@ -126,14 +122,12 @@ internal class ControlBarViewModelUnitTest {
             callingViewModel.update(
                 permissionState,
                 cameraState,
-                audioState1,
-                callingState
+                audioState1
             )
             callingViewModel.update(
                 permissionState,
                 cameraState,
-                audioState2,
-                callingState
+                audioState2
             )
 
             // assert
@@ -164,7 +158,6 @@ internal class ControlBarViewModelUnitTest {
 
             val cameraState = CameraState(CameraOperationalStatus.OFF, CameraDeviceSelectionStatus.FRONT, CameraTransmissionStatus.REMOTE)
             val audioDeviceState = AudioDeviceSelectionStatus.RECEIVER_SELECTED
-            val callingState = CallingState(CallingStatus.CONNECTED)
 
             val resultListFromCameraPermissionStateFlow =
                 mutableListOf<ControlBarViewModel.CameraModel>()
@@ -179,8 +172,7 @@ internal class ControlBarViewModelUnitTest {
             callingViewModel.init(
                 initialPermissionState,
                 cameraState,
-                AudioState(AudioOperationalStatus.OFF, audioDeviceState),
-                callingState,
+                AudioState(AudioOperationalStatus.OFF, audioDeviceState)
             )
 
             val flowJob = launch {
@@ -192,14 +184,12 @@ internal class ControlBarViewModelUnitTest {
             callingViewModel.update(
                 permissionState1,
                 cameraState,
-                AudioState(AudioOperationalStatus.OFF, audioDeviceState),
-                callingState,
+                AudioState(AudioOperationalStatus.OFF, audioDeviceState)
             )
             callingViewModel.update(
                 permissionState2,
                 cameraState,
-                AudioState(AudioOperationalStatus.OFF, audioDeviceState),
-                callingState,
+                AudioState(AudioOperationalStatus.OFF, audioDeviceState)
             )
 
             // assert
@@ -231,7 +221,6 @@ internal class ControlBarViewModelUnitTest {
             )
 
             val audioDeviceState = AudioDeviceSelectionStatus.RECEIVER_SELECTED
-            val callingState = CallingState(CallingStatus.CONNECTED)
             val cameraDeviceSelectionStatus = CameraDeviceSelectionStatus.FRONT
             val cameraTransmissionStatus = CameraTransmissionStatus.REMOTE
 
@@ -246,8 +235,7 @@ internal class ControlBarViewModelUnitTest {
             callingViewModel.init(
                 permissionState,
                 initialCameraState,
-                AudioState(AudioOperationalStatus.OFF, audioDeviceState),
-                callingState
+                AudioState(AudioOperationalStatus.OFF, audioDeviceState)
             )
 
             val resultListFromCameraStateFlow = mutableListOf<ControlBarViewModel.CameraModel>()
@@ -259,14 +247,12 @@ internal class ControlBarViewModelUnitTest {
             callingViewModel.update(
                 permissionState,
                 cameraState1,
-                AudioState(AudioOperationalStatus.OFF, audioDeviceState),
-                callingState,
+                AudioState(AudioOperationalStatus.OFF, audioDeviceState)
             )
             callingViewModel.update(
                 permissionState,
                 cameraState2,
-                AudioState(AudioOperationalStatus.OFF, audioDeviceState),
-                callingState,
+                AudioState(AudioOperationalStatus.OFF, audioDeviceState)
             )
 
             // assert


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Reflect the real audio state which set up in set up screen

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
1. Join the Teams Meeting, set up your audio mute/unmute
2. Access waiting for lobby view
3. Check the audio state in the lobby
```
```
## What to Check
Verify that the following are valid
* Check set up screen and lobby screen have same audio state
