### PR TITLE
[BugFix] From config screen joining call back on network reconnect display recording banner in lobby state

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingFragment.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingFragment.kt
@@ -122,6 +122,7 @@ internal class CallingFragment(
         if (activity?.isChangingConfigurations == false) {
             participantGridView.stop()
             confirmLeaveOverlayView.stop()
+            viewModel.getBannerViewModel().dismissBanner()
         }
         localParticipantView.stop()
         participantListView.stop()

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandler.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandler.kt
@@ -327,6 +327,8 @@ internal class CallingMiddlewareActionHandlerImpl(
                     store.dispatch(action)
 
                     if (it.callCompositeErrorCode == CallCompositeErrorCode.CALL_END || it.callCompositeErrorCode == CallCompositeErrorCode.CALL_JOIN) {
+                        store.dispatch(CallingAction.IsTranscribingUpdated(false))
+                        store.dispatch(CallingAction.IsRecordingUpdated(false))
                         store.dispatch(ParticipantAction.ListUpdated())
                         store.dispatch(CallingAction.StateUpdated(CallingStatus.NONE))
                         store.dispatch(NavigationAction.SetupLaunched())

--- a/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandlerUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandlerUnitTest.kt
@@ -1268,6 +1268,20 @@ internal class CallingMiddlewareActionHandlerUnitTest {
             // assert
             verify(mockAppStore, times(1)).dispatch(
                 argThat { action ->
+                    action is CallingAction.IsTranscribingUpdated &&
+                        !action.isTranscribing
+                }
+            )
+
+            verify(mockAppStore, times(1)).dispatch(
+                argThat { action ->
+                    action is CallingAction.IsRecordingUpdated &&
+                        !action.isRecording
+                }
+            )
+
+            verify(mockAppStore, times(1)).dispatch(
+                argThat { action ->
                     action is ErrorAction.CallStateErrorOccurred &&
                         action.callStateError.callCompositeErrorCode == CallCompositeErrorCode.CALL_END
                 }


### PR DESCRIPTION
## Purpose
* Fix bug to not displays recording and transcription banner in lobby call state when teams call is joined from config screen after network disconnect error

## Impact
The code changes can have impact on banner display when device screen rotates as well as background mode. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
### Scenario 1
  * Join teams call
  * Start recording from teams client
  * UI library will display recording banner on call screen
  * Disconnect network on mobile device
  * On network error at setup screen, connect to network and join call
  * Banner should be displayed when user is admitted
 
 ### Scenario 2
  * Join teams call
  * Start recording from teams client
  * UI library will display recording banner on call screen
  * Disconnect network on mobile device
  * Stop recording from teams call
  * On network error at setup screen, connect to network and join call
  * Banner should not be displayed when user is admitted

## What to Check
*Verify that the joining call back from setup screen(after network error) is not displaying banner until the call state is not connected
*Verify that banner for recording and transcription is displayed on screen rotation as well as when back from background mode 