### PR TITLE
[BugFix] Status bar color change

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/MainActivity.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/MainActivity.kt
@@ -7,10 +7,14 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
+import android.content.res.Configuration
 import android.graphics.drawable.ColorDrawable
 import android.media.AudioManager
+import android.os.Build
 import android.os.Bundle
 import android.view.MenuItem
+import android.view.View
+import android.view.WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
 import android.view.WindowManager
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
@@ -71,6 +75,7 @@ internal class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         configureActionBar()
+        setStatusBarColor()
         setActionBarVisibility()
         if (configuration.themeConfig?.theme != null) {
             theme.applyStyle(
@@ -230,6 +235,39 @@ internal class MainActivity : AppCompatActivity() {
         val transaction: FragmentTransaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.azure_communication_ui_fragment_container_view, fragment)
         transaction.commit()
+    }
+
+    private fun setStatusBarColor() {
+        window.statusBarColor = ContextCompat.getColor(
+            this,
+            R.color.azure_communication_ui_color_status_bar
+        )
+
+        val isNightMode = this.resources.configuration.uiMode
+            .and(Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+
+        if (isNightMode) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                window.insetsController?.setSystemBarsAppearance(0, APPEARANCE_LIGHT_STATUS_BARS)
+            } else {
+                window.clearFlags(0)
+            }
+        } else {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                window.insetsController?.setSystemBarsAppearance(
+                    APPEARANCE_LIGHT_STATUS_BARS,
+                    APPEARANCE_LIGHT_STATUS_BARS
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                window.decorView.systemUiVisibility =
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+                    } else {
+                        View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+                    }
+            }
+        }
     }
 
     private fun startService() {

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-night/azure_communication_ui_colors.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-night/azure_communication_ui_colors.xml
@@ -17,6 +17,7 @@
     <color name="azure_communication_ui_color_on_success">#141414</color>
     <color name="azure_communication_ui_color_call_lobby_overlay">#99141414</color>
     <color name="azure_communication_ui_color_participant_list_mute_mic">#6E6E6E</color>
+    <color name="azure_communication_ui_color_status_bar">#000000</color>
 
     <!--Static colors-->
     <color name="azure_communication_ui_color_on_surface_camera_active">#FFFFFF</color>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values/azure_communication_ui_colors.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values/azure_communication_ui_colors.xml
@@ -18,6 +18,7 @@
     <color name="azure_communication_ui_color_call_leave_overlay">#CC000000</color>
     <color name="azure_communication_ui_color_call_lobby_overlay">#CCFFFFFF</color>
     <color name="azure_communication_ui_color_participant_list_mute_mic">#919191</color>
+    <color name="azure_communication_ui_color_status_bar">#ffffff</color>
 
     <!--Static colors-->
     <color name="azure_communication_ui_color_on_surface_camera_active">#FFFFFF</color>


### PR DESCRIPTION
## Purpose
Fixed status bar color. Light/Dark mode toggle is only available on API >= 29. On API < 29, status bar color will be white as light mode is on by default.

## Impact
Status bar color changes to black when dark mode is on, changes to white when light mode is on. 

![Screen Shot 2021-12-15 at 5 56 24 PM](https://user-images.githubusercontent.com/24381490/146295199-b889eaf2-d793-4865-9f3c-d07ecc08ca14.png)

![Screen Shot 2021-12-15 at 5 56 57 PM](https://user-images.githubusercontent.com/24381490/146295204-224fbcaf-28a8-4074-b015-0a2760feed12.png)



## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
Test status bar color on light and dark mode on various API levels.

## What to Check
Verify that the following are valid
Status bar color on API 29+ and API < 29

