### PR TITLE
[BugFix] Fix margin for the mute-mic/checkmark icon

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/res/layout/azure_communication_ui_bottom_drawer_cell.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/layout/azure_communication_ui_bottom_drawer_cell.xml
@@ -48,7 +48,7 @@
         android:id="@+id/cell_check_mark"
         android:layout_width="20dp"
         android:layout_height="20dp"
-        android:layout_marginEnd="10dp"
+        android:layout_marginEnd="12dp"
         android:background="@android:color/transparent"
         android:clickable="false"
         android:src="@drawable/ms_ic_checkmark_24_filled"


### PR DESCRIPTION
## Purpose
Base on the Figma spec [https://www.figma.com/file/BOeihN2NJE7ROdyqbihCxi/Mobile-UI-Library?node-id=20%3A4324](url), The separate line to the end margin is 16dp, the mute-mic icon to the end margin is 18dp. So this PR is fixing this margin problem.
impact: participant list & audio device select menu

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Join a group call or Teams call with few remote participants.
Click on the audio device button on the bottom bar or entry of participant list button on the header banner to open up the audio device menu or participant list to verify the margin of the icon.