### PR TITLE
[BUG] Potentially leaking bindings in AudioSessionManager

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/manager/AudioSessionManager.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/manager/AudioSessionManager.kt
@@ -141,7 +141,7 @@ internal class AudioSessionManager(
             closeProfileProxy(BluetoothProfile.HEADSET, bluetoothAudioProxy)
             context.unregisterReceiver(this@AudioSessionManager)
         }
-        started=false
+        started = false
     }
 
     override fun onServiceConnected(profile: Int, proxy: BluetoothProfile?) {

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/manager/AudioSessionManager.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/manager/AudioSessionManager.kt
@@ -26,6 +26,8 @@ internal class AudioSessionManager(
 
     private var bluetoothAudioProxy: BluetoothHeadset? = null
 
+    private var started = false
+
     private val isBluetoothScoAvailable get() =
         context.resources.getBoolean(R.bool.azure_communication_ui_feature_flag_bluetooth_audio) &&
             (bluetoothAudioProxy?.connectedDevices?.size ?: 0 > 0)
@@ -33,6 +35,9 @@ internal class AudioSessionManager(
     private var previousAudioDeviceSelectionStatus: AudioDeviceSelectionStatus? = null
 
     suspend fun start() {
+        if (started) return
+        started = true
+
         BluetoothAdapter.getDefaultAdapter()?.run {
             getProfileProxy(context, this@AudioSessionManager, BluetoothProfile.HEADSET)
 
@@ -136,6 +141,7 @@ internal class AudioSessionManager(
             closeProfileProxy(BluetoothProfile.HEADSET, bluetoothAudioProxy)
             context.unregisterReceiver(this@AudioSessionManager)
         }
+        started=false
     }
 
     override fun onServiceConnected(profile: Int, proxy: BluetoothProfile?) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Prevent start() from taking effect multiple times, thus avoiding multiple registrations of the bluetooth listener.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

1) Enable feature flag, connect a bluetooth headset
2) Rotate phone or put in background and restore
3) Exit call
4) Run a forced GC and then inspect the head for AudioSessionManager to see if the callbacks are still in memory.

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
