### PR TITLE
[Bug] revert navigation router refactoring

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/CallCompositeActivity.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/CallCompositeActivity.kt
@@ -28,7 +28,6 @@ import com.azure.android.communication.ui.presentation.fragment.setup.SetupFragm
 import com.azure.android.communication.ui.presentation.navigation.BackNavigation
 import com.azure.android.communication.ui.redux.action.CallingAction
 import com.azure.android.communication.ui.redux.state.NavigationStatus
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 internal class CallCompositeActivity : AppCompatActivity() {
@@ -49,6 +48,7 @@ internal class CallCompositeActivity : AppCompatActivity() {
     private val instanceId get() = intent.getIntExtra(KEY_INSTANCE_ID, -1)
 
     override fun onDestroy() {
+        navigationRouter.removeOnNavigationStateChanged(this::onNavigationStateChange)
         if (isFinishing) {
             store.dispatch(CallingAction.CallEndRequested())
             audioSessionManager.stop()
@@ -88,9 +88,7 @@ internal class CallCompositeActivity : AppCompatActivity() {
 
         lifecycleScope.launch { audioSessionManager.start() }
 
-        lifecycleScope.launchWhenStarted {
-            navigationRouter.getNavigationStateFlow().collect { onNavigationStateChange(it) }
-        }
+        navigationRouter.addOnNavigationStateChanged(this::onNavigationStateChange)
 
         lifecycleScope.launch {
             navigationRouter.start()

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/navigation/NavigationRouter.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/navigation/NavigationRouter.kt
@@ -4,9 +4,9 @@
 package com.azure.android.communication.ui.presentation.navigation
 
 import com.azure.android.communication.ui.redux.state.NavigationStatus
-import kotlinx.coroutines.flow.StateFlow
 
 internal interface NavigationRouter {
     suspend fun start()
-    fun getNavigationStateFlow(): StateFlow<NavigationStatus>
+    fun addOnNavigationStateChanged(callback: (navigationState: NavigationStatus) -> Unit)
+    fun removeOnNavigationStateChanged(callback: (navigationState: NavigationStatus) -> Unit)
 }

--- a/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/navigation/NavigationRouterUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/navigation/NavigationRouterUnitTest.kt
@@ -10,9 +10,7 @@ import com.azure.android.communication.ui.redux.state.NavigationState
 import com.azure.android.communication.ui.redux.state.NavigationStatus
 import com.azure.android.communication.ui.redux.state.ReduxState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert
@@ -33,19 +31,13 @@ internal class NavigationRouterUnitTest {
     @get:Rule
     var mainCoroutineRule = MainCoroutineRule()
 
-    private fun createNavigationRouter(stateFlow: MutableStateFlow<ReduxState>):
-        Pair<NavigationRouter, List<NavigationStatus>> {
-
+    private fun createNavigationRouter(stateFlow: MutableStateFlow<ReduxState>): Pair<NavigationRouter, List<NavigationStatus>> {
         val mockAppStore = mock<AppStore<ReduxState>> {
             on { getStateFlow() } doReturn stateFlow
         }
         val navigationRouter = NavigationRouterImpl(mockAppStore)
         val receivedUpdates = mutableListOf<NavigationStatus>()
-
-        val scope = MainScope()
-        scope.launch {
-            navigationRouter.getNavigationStateFlow().collect { receivedUpdates.add(it) }
-        }
+        navigationRouter.addOnNavigationStateChanged { receivedUpdates.add(it) }
 
         return Pair(navigationRouter, receivedUpdates)
     }
@@ -74,10 +66,9 @@ internal class NavigationRouterUnitTest {
                 }
 
             // assert
-            Assert.assertEquals(3, receivedUpdates.count())
-            Assert.assertEquals(NavigationStatus.NONE, receivedUpdates[0])
-            Assert.assertEquals(NavigationStatus.SETUP, receivedUpdates[1])
-            Assert.assertEquals(NavigationStatus.IN_CALL, receivedUpdates[2])
+            Assert.assertEquals(2, receivedUpdates.count())
+            Assert.assertEquals(NavigationStatus.SETUP, receivedUpdates[0])
+            Assert.assertEquals(NavigationStatus.IN_CALL, receivedUpdates[1])
 
             navigationRouterLaunchJob.cancel()
         }
@@ -102,9 +93,9 @@ internal class NavigationRouterUnitTest {
             stateFlow.value = appState
 
             // assert
-            Assert.assertEquals(3, receivedUpdates.count())
-            Assert.assertEquals(initialState.navigationState.navigationState, receivedUpdates[1])
-            Assert.assertEquals(appState.navigationState.navigationState, receivedUpdates[2])
+            Assert.assertEquals(2, receivedUpdates.count())
+            Assert.assertEquals(initialState.navigationState.navigationState, receivedUpdates[0])
+            Assert.assertEquals(appState.navigationState.navigationState, receivedUpdates[1])
 
             navigationRouterLaunchJob.cancel()
         }
@@ -136,8 +127,8 @@ internal class NavigationRouterUnitTest {
                 }
 
             // assert
-            Assert.assertEquals(2, receivedUpdates.count())
-            Assert.assertEquals(NavigationStatus.IN_CALL, receivedUpdates[1])
+            Assert.assertEquals(1, receivedUpdates.count())
+            Assert.assertEquals(NavigationStatus.IN_CALL, receivedUpdates[0])
 
             navigationRouterLaunchJob.cancel()
         }
@@ -166,8 +157,8 @@ internal class NavigationRouterUnitTest {
                 }
 
             // assert
-            Assert.assertEquals(2, receivedUpdates.count())
-            Assert.assertEquals(NavigationStatus.SETUP, receivedUpdates[1])
+            Assert.assertEquals(1, receivedUpdates.count())
+            Assert.assertEquals(NavigationStatus.SETUP, receivedUpdates[0])
 
             navigationRouterLaunchJob.cancel()
         }
@@ -197,11 +188,10 @@ internal class NavigationRouterUnitTest {
                 }
 
             // assert
-            Assert.assertEquals(4, receivedUpdates.count())
-            Assert.assertEquals(NavigationStatus.NONE, receivedUpdates[0])
-            Assert.assertEquals(NavigationStatus.SETUP, receivedUpdates[1])
-            Assert.assertEquals(NavigationStatus.IN_CALL, receivedUpdates[2])
-            Assert.assertEquals(NavigationStatus.SETUP, receivedUpdates[3])
+            Assert.assertEquals(3, receivedUpdates.count())
+            Assert.assertEquals(NavigationStatus.SETUP, receivedUpdates[0])
+            Assert.assertEquals(NavigationStatus.IN_CALL, receivedUpdates[1])
+            Assert.assertEquals(NavigationStatus.SETUP, receivedUpdates[2])
 
             navigationRouterLaunchJob.cancel()
         }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* reverting navigation router refactoring as it caused below bug for not displaying banner/call hangup overlay on screen rotate. On screen rotate fragment is launched twice because of this change

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* rotate screen and make sure recording banner/grid/call hangup displayed
* join call waiting indicator should work as before
