### PR TITLE
[Refactor] Ignore some UI elements and show up info header for user with Talkback on

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingFragment.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingFragment.kt
@@ -11,6 +11,7 @@ import android.hardware.SensorManager
 import android.os.Bundle
 import android.os.PowerManager
 import android.view.View
+import android.view.accessibility.AccessibilityManager
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
@@ -48,6 +49,7 @@ internal class CallingFragment :
     private lateinit var lobbyOverlay: LobbyOverlayView
     private lateinit var sensorManager: SensorManager
     private lateinit var powerManager: PowerManager
+    private lateinit var accessibilityManager: AccessibilityManager
     private lateinit var wakeLock: PowerManager.WakeLock
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -87,11 +89,13 @@ internal class CallingFragment :
             videoViewManager,
         )
 
+        accessibilityManager = context?.applicationContext?.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
         infoHeaderView = view.findViewById(R.id.azure_communication_ui_call_floating_header)
         infoHeaderView.start(
             viewLifecycleOwner,
             viewModel.getFloatingHeaderViewModel(),
-            this::displayParticipantList
+            this::displayParticipantList,
+            accessibilityManager.isEnabled
         )
 
         audioDeviceListView =

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderView.kt
@@ -5,9 +5,7 @@ package com.azure.android.communication.ui.presentation.fragment.calling.header
 
 import android.content.Context
 import android.util.AttributeSet
-import android.util.Log
 import android.view.View
-import android.view.accessibility.AccessibilityManager
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderView.kt
@@ -5,7 +5,9 @@ package com.azure.android.communication.ui.presentation.fragment.calling.header
 
 import android.content.Context
 import android.util.AttributeSet
+import android.util.Log
 import android.view.View
+import android.view.accessibility.AccessibilityManager
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -41,13 +43,18 @@ internal class InfoHeaderView : ConstraintLayout {
         viewLifecycleOwner: LifecycleOwner,
         infoHeaderViewModel: InfoHeaderViewModel,
         displayParticipantList: () -> Unit,
+        accessibilityEnabled: Boolean
     ) {
         this.infoHeaderViewModel = infoHeaderViewModel
         this.displayParticipantListCallback = displayParticipantList
 
         viewLifecycleOwner.lifecycleScope.launch {
-            infoHeaderViewModel.getDisplayFloatingHeaderFlow().collect {
-                floatingHeader.visibility = if (it) View.VISIBLE else View.INVISIBLE
+            if (accessibilityEnabled) {
+                floatingHeader.visibility = View.VISIBLE
+            } else {
+                infoHeaderViewModel.getDisplayFloatingHeaderFlow().collect {
+                    floatingHeader.visibility = if (it) View.VISIBLE else View.INVISIBLE
+                }
             }
         }
 

--- a/azure-communication-ui/azure-communication-ui/src/main/res/layout/azure_communication_ui_call_header.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/layout/azure_communication_ui_call_header.xml
@@ -5,6 +5,7 @@
 <com.azure.android.communication.ui.presentation.fragment.calling.header.InfoHeaderView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/azure_communication_ui_call_floating_header"
+    android:importantForAccessibility="yes"
     android:layout_width="match_parent"
     android:layout_height="58dp"
     android:layout_marginStart="8dp"
@@ -20,6 +21,7 @@
 
     <TextView
         android:id="@+id/azure_communication_ui_call_participant_number_text"
+        android:importantForAccessibility="no"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"

--- a/azure-communication-ui/azure-communication-ui/src/main/res/layout/azure_communication_ui_fragment_setup.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/layout/azure_communication_ui_fragment_setup.xml
@@ -32,6 +32,7 @@
 
         <com.azure.android.communication.ui.presentation.fragment.setup.components.PreviewAreaView
             android:id="@+id/azure_communication_ui_setup_local_video_holder"
+            android:importantForAccessibility="no"
             android:layout_width="0dp"
             android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -54,6 +55,7 @@
 
         <com.azure.android.communication.ui.presentation.fragment.setup.components.SetupGradientView
             android:id="@+id/azure_communication_ui_setup_gradient"
+            android:importantForAccessibility="no"
             android:layout_width="0dp"
             android:layout_height="140dp"
             android:alpha="0.6"
@@ -178,6 +180,7 @@
             android:layout_height="0dp"
             android:backgroundTint="@color/azure_communication_ui_primary_selector"
             android:clickable="true"
+            android:focusable="true"
             android:enabled="true"
             android:text="@string/azure_communication_ui_setup_join_call"
             android:textSize="0sp"
@@ -191,6 +194,7 @@
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/azure_communication_ui_setup_start_call_button_text"
             style="@style/AzureCommunicationUICalling.ButtonText"
+            android:importantForAccessibility="no"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:drawablePadding="4dp"


### PR DESCRIPTION
## Purpose
Ignore some UI elements for Talkback.
Modify the logic to always keep info header showing up when the Talkback is on

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Test the App with Talkback on, use gesture(swipe left or right) to navigate the UI elements on Setup screen to verify if some UI elements have been ignored. (Also same for the participants' number on the info header).
Try to join the call with or without Talkback on, to see if the info header show up as expected.