### PR TITLE
[Feature] Let Talkback read confirm leave overlay properly

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/di/DependencyInjectionContainerImpl.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/di/DependencyInjectionContainerImpl.kt
@@ -25,6 +25,7 @@ import com.azure.android.communication.ui.redux.middleware.CallingMiddlewareImpl
 import com.azure.android.communication.ui.redux.middleware.handler.CallingMiddlewareActionHandlerImpl
 import com.azure.android.communication.ui.redux.reducer.AppStateReducer
 import com.azure.android.communication.ui.redux.reducer.CallStateReducerImpl
+import com.azure.android.communication.ui.redux.reducer.DisplayReducerImpl
 import com.azure.android.communication.ui.redux.reducer.ErrorReducerImpl
 import com.azure.android.communication.ui.redux.reducer.LifecycleReducerImpl
 import com.azure.android.communication.ui.redux.reducer.LocalParticipantStateReducerImpl
@@ -110,6 +111,7 @@ internal class DependencyInjectionContainerImpl(
     private val lifecycleReducer get() = LifecycleReducerImpl()
     private val errorReducer get() = ErrorReducerImpl()
     private val navigationReducer get() = NavigationReducerImpl()
+    private val displayReducer get() = DisplayReducerImpl()
 
     // Middleware
     private val appMiddleware get() = mutableListOf(callingMiddleware)
@@ -128,7 +130,8 @@ internal class DependencyInjectionContainerImpl(
             permissionStateReducer,
             lifecycleReducer,
             errorReducer,
-            navigationReducer
+            navigationReducer,
+            displayReducer
         ) as Reducer<ReduxState>
     }
     //endregion

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingFragment.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingFragment.kt
@@ -66,7 +66,6 @@ internal class CallingFragment :
         controlBarView.start(
             viewLifecycleOwner,
             viewModel.getControlBarViewModel(),
-            this::requestCallEnd,
             this::openAudioDeviceSelectionMenu
         )
 

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingViewModel.kt
@@ -15,6 +15,7 @@ import com.azure.android.communication.ui.presentation.fragment.calling.particip
 import com.azure.android.communication.ui.presentation.fragment.common.audiodevicelist.AudioDeviceListViewModel
 import com.azure.android.communication.ui.presentation.fragment.factories.CallingViewModelFactory
 import com.azure.android.communication.ui.redux.Store
+import com.azure.android.communication.ui.redux.action.DisplayAction
 import com.azure.android.communication.ui.redux.state.CallingStatus
 import com.azure.android.communication.ui.redux.state.LifecycleStatus
 import com.azure.android.communication.ui.redux.state.ReduxState
@@ -82,7 +83,7 @@ internal class CallingViewModel(
     }
 
     fun requestCallEnd() {
-        confirmLeaveOverlayViewModel.requestExitConfirmation()
+        dispatchAction(action = DisplayAction.IsConfirmLeaveOverlayDisplayed(true))
     }
 
     override fun init(coroutineScope: CoroutineScope) {
@@ -91,7 +92,8 @@ internal class CallingViewModel(
         controlBarViewModel.init(
             state.permissionState,
             state.localParticipantState.cameraState,
-            state.localParticipantState.audioState
+            state.localParticipantState.audioState,
+            state.displayState.confirmLeaveOverlayDisplayState
         )
 
         localParticipantViewModel.init(
@@ -101,16 +103,19 @@ internal class CallingViewModel(
             state.remoteParticipantState.participantMap.count(),
             state.callState.CallingStatus,
             state.localParticipantState.cameraState.device,
+            state.displayState.confirmLeaveOverlayDisplayState
         )
 
         floatingHeaderViewModel.init(
-            state.remoteParticipantState.participantMap.count()
+            state.remoteParticipantState.participantMap.count(),
+            state.displayState.confirmLeaveOverlayDisplayState
         )
         audioDeviceListViewModel.init(
             state.localParticipantState.audioState.device
         )
         bannerViewModel.init(
-            state.callState
+            state.callState,
+            state.displayState.confirmLeaveOverlayDisplayState
         )
 
         participantListViewModel.init(
@@ -118,7 +123,13 @@ internal class CallingViewModel(
             state.localParticipantState
         )
 
-        lobbyOverlayViewModel.init(state.callState.CallingStatus)
+        confirmLeaveOverlayViewModel.init(state.displayState.confirmLeaveOverlayDisplayState)
+        participantGridViewModel.init(state.displayState.confirmLeaveOverlayDisplayState)
+
+        lobbyOverlayViewModel.init(
+            state.callState.CallingStatus,
+            state.displayState.confirmLeaveOverlayDisplayState
+        )
 
         super.init(coroutineScope)
     }
@@ -143,7 +154,7 @@ internal class CallingViewModel(
             state.localParticipantState.videoStreamID,
             state.remoteParticipantState.participantMap.count(),
             state.callState.CallingStatus,
-            state.localParticipantState.cameraState.device,
+            state.localParticipantState.cameraState.device
         )
 
         audioDeviceListViewModel.update(
@@ -151,7 +162,9 @@ internal class CallingViewModel(
             state.localParticipantState.audioState.isBluetoothSCOAvailable
         )
 
-        lobbyOverlayViewModel.update(state.callState.CallingStatus)
+        lobbyOverlayViewModel.update(
+            state.callState.CallingStatus
+        )
 
         if (shouldUpdateRemoteParticipantsViewModels(state)) {
             participantGridViewModel.update(
@@ -172,8 +185,20 @@ internal class CallingViewModel(
                 state.callState
             )
         }
+
+        updateConfirmLeaveOverlayDisplayState(state.displayState.confirmLeaveOverlayDisplayState)
     }
 
     private fun shouldUpdateRemoteParticipantsViewModels(state: ReduxState) =
         state.callState.CallingStatus == CallingStatus.CONNECTED
+
+    private fun updateConfirmLeaveOverlayDisplayState(isDisplayed: Boolean) {
+        confirmLeaveOverlayViewModel.updateConfirmLeaveOverlayDisplayState(isDisplayed)
+        participantGridViewModel.updateConfirmLeaveOverlayDisplayState(isDisplayed)
+        floatingHeaderViewModel.updateConfirmLeaveOverlayDisplayState(isDisplayed)
+        bannerViewModel.updateConfirmLeaveOverlayDisplayState(isDisplayed)
+        controlBarViewModel.updateConfirmLeaveOverlayDisplayState(isDisplayed)
+        localParticipantViewModel.updateConfirmLeaveOverlayDisplayState(isDisplayed)
+        lobbyOverlayViewModel.updateConfirmLeaveOverlayDisplayState(isDisplayed)
+    }
 }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerView.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.azure.android.communication.ui.R
@@ -21,6 +22,7 @@ internal class BannerView : ConstraintLayout {
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
 
+    private lateinit var bannerView: View
     private lateinit var bannerText: TextView
     private lateinit var bannerCloseButton: ImageButton
 
@@ -47,6 +49,16 @@ internal class BannerView : ConstraintLayout {
                     } else {
                         View.GONE
                     }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.getIsConfirmLeaveOverlayDisplayedStateFlow().collect {
+                if (it) {
+                    ViewCompat.setImportantForAccessibility(bannerView, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+                } else {
+                    ViewCompat.setImportantForAccessibility(bannerView, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES)
+                }
             }
         }
     }
@@ -117,7 +129,7 @@ internal class BannerView : ConstraintLayout {
 
     override fun onFinishInflate() {
         super.onFinishInflate()
-
+        bannerView = findViewById(R.id.azure_communication_ui_call_banner)
         bannerText = findViewById(R.id.azure_communication_ui_call_banner_text)
         bannerCloseButton = findViewById(R.id.azure_communication_ui_call_banner_close)
 

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
 internal class BannerViewModel {
 
     private lateinit var bannerInfoTypeStateFlow: MutableStateFlow<BannerInfoType>
+    private lateinit var isConfirmLeaveOverlayDisplayedStateFlow: MutableStateFlow<Boolean>
     private var shouldShowBannerStateFlow = MutableStateFlow(false)
 
     private var recordingState: ComplianceState = ComplianceState.OFF
@@ -23,10 +24,14 @@ internal class BannerViewModel {
         return shouldShowBannerStateFlow
     }
 
-    fun init(callingState: CallingState) {
+    fun init(
+        callingState: CallingState,
+        confirmLeaveOverlayDisplayState: Boolean
+    ) {
         bannerInfoTypeStateFlow = MutableStateFlow(
             createBannerInfoType(callingState.isRecording, callingState.isTranscribing)
         )
+        isConfirmLeaveOverlayDisplayedStateFlow = MutableStateFlow(confirmLeaveOverlayDisplayState)
     }
 
     private fun createBannerInfoType(
@@ -97,7 +102,9 @@ internal class BannerViewModel {
         }
     }
 
-    fun update(callingState: CallingState) {
+    fun update(
+        callingState: CallingState
+    ) {
         val currentBannerInfoType = bannerInfoTypeStateFlow.value
         val newBannerInfoType =
             createBannerInfoType(callingState.isRecording, callingState.isTranscribing)
@@ -108,9 +115,20 @@ internal class BannerViewModel {
         }
     }
 
+    fun updateConfirmLeaveOverlayDisplayState(
+        confirmLeaveOverlayDisplayState: Boolean
+    ) {
+        isConfirmLeaveOverlayDisplayedStateFlow.value =
+            confirmLeaveOverlayDisplayState
+    }
+
     fun dismissBanner() {
         shouldShowBannerStateFlow.value = false
         resetStoppedStates()
+    }
+
+    fun getIsConfirmLeaveOverlayDisplayedStateFlow(): StateFlow<Boolean> {
+        return isConfirmLeaveOverlayDisplayedStateFlow
     }
 
     private fun resetStoppedStates() {

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/controlbar/ControlBarViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/controlbar/ControlBarViewModel.kt
@@ -4,6 +4,7 @@
 package com.azure.android.communication.ui.presentation.fragment.calling.controlbar
 
 import com.azure.android.communication.ui.redux.action.Action
+import com.azure.android.communication.ui.redux.action.DisplayAction
 import com.azure.android.communication.ui.redux.action.LocalParticipantAction
 import com.azure.android.communication.ui.redux.state.AudioDeviceSelectionStatus
 import com.azure.android.communication.ui.redux.state.AudioOperationalStatus
@@ -21,11 +22,13 @@ internal class ControlBarViewModel(
     private lateinit var audioOperationalStatusStateFlow: MutableStateFlow<AudioOperationalStatus>
     private lateinit var audioDeviceSelectionStatusStateFlow: MutableStateFlow<AudioDeviceSelectionStatus>
     private lateinit var shouldEnableMicButtonStateFlow: MutableStateFlow<Boolean>
+    private lateinit var isConfirmLeaveOverlayDisplayedStateFlow: MutableStateFlow<Boolean>
 
     fun init(
         permissionState: PermissionState,
         cameraState: CameraState,
         audioState: AudioState,
+        confirmLeaveOverlayDisplayState: Boolean
     ) {
         cameraStateFlow =
             MutableStateFlow(CameraModel(permissionState.cameraPermissionState, cameraState))
@@ -33,17 +36,25 @@ internal class ControlBarViewModel(
         audioDeviceSelectionStatusStateFlow = MutableStateFlow(audioState.device)
         shouldEnableMicButtonStateFlow =
             MutableStateFlow(shouldEnableMicButton(audioState))
+        isConfirmLeaveOverlayDisplayedStateFlow = MutableStateFlow(confirmLeaveOverlayDisplayState)
     }
 
     fun update(
         permissionState: PermissionState,
         cameraState: CameraState,
-        audioState: AudioState,
+        audioState: AudioState
     ) {
         cameraStateFlow.value = CameraModel(permissionState.cameraPermissionState, cameraState)
         audioOperationalStatusStateFlow.value = audioState.operation
         audioDeviceSelectionStatusStateFlow.value = audioState.device
         shouldEnableMicButtonStateFlow.value = shouldEnableMicButton(audioState)
+    }
+
+    fun updateConfirmLeaveOverlayDisplayState(
+        confirmLeaveOverlayDisplayState: Boolean
+    ) {
+        isConfirmLeaveOverlayDisplayedStateFlow.value =
+            confirmLeaveOverlayDisplayState
     }
 
     fun getAudioOperationalStatusStateFlow(): StateFlow<AudioOperationalStatus> {
@@ -76,6 +87,14 @@ internal class ControlBarViewModel(
 
     fun turnCameraOff() {
         dispatchAction(action = LocalParticipantAction.CameraOffTriggered())
+    }
+
+    fun openConfirmLeaveOverlay() {
+        dispatchAction(action = DisplayAction.IsConfirmLeaveOverlayDisplayed(true))
+    }
+
+    fun getIsConfirmLeaveOverlayDisplayedStateFlow(): StateFlow<Boolean> {
+        return isConfirmLeaveOverlayDisplayedStateFlow
     }
 
     private fun shouldEnableMicButton(audioState: AudioState): Boolean {

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/hangup/ConfirmLeaveOverlayView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/hangup/ConfirmLeaveOverlayView.kt
@@ -5,6 +5,8 @@ package com.azure.android.communication.ui.presentation.fragment.calling.hangup
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.Button
 import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
@@ -48,8 +50,14 @@ internal class ConfirmLeaveOverlayView : LinearLayout {
         this.confirmLeaveOverlayViewModel = confirmLeaveOverlayViewModel
 
         viewLifecycleOwner.lifecycleScope.launch {
-            confirmLeaveOverlayViewModel.getShouldDisplayConfirmLeaveOverlayFlow().collect {
-                visibility = if (it) VISIBLE else GONE
+            confirmLeaveOverlayViewModel.getIsConfirmLeaveOverlayDisplayedStateFlow().collect {
+                if (it) {
+                    visibility = VISIBLE
+                    confirmLeaveCallButton.performAccessibilityAction(AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS, null)
+                    confirmLeaveCallButton.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_CLICKED)
+                } else {
+                    visibility = GONE
+                }
             }
         }
     }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/hangup/ConfirmLeaveOverlayViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/hangup/ConfirmLeaveOverlayViewModel.kt
@@ -5,16 +5,29 @@ package com.azure.android.communication.ui.presentation.fragment.calling.hangup
 
 import com.azure.android.communication.ui.redux.action.Action
 import com.azure.android.communication.ui.redux.action.CallingAction
+import com.azure.android.communication.ui.redux.action.DisplayAction
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 internal class ConfirmLeaveOverlayViewModel(
     private val dispatch: (Action) -> Unit,
 ) {
-    private val shouldDisplayConfirmLeaveOverlayStateFlow = MutableStateFlow(false)
+    private lateinit var isConfirmLeaveOverlayDisplayedStateFlow: MutableStateFlow<Boolean>
 
-    fun getShouldDisplayConfirmLeaveOverlayFlow(): StateFlow<Boolean> {
-        return shouldDisplayConfirmLeaveOverlayStateFlow
+    fun init(
+        confirmLeaveOverlayDisplayState: Boolean
+    ) {
+        isConfirmLeaveOverlayDisplayedStateFlow =
+            MutableStateFlow(confirmLeaveOverlayDisplayState)
+    }
+
+    fun updateConfirmLeaveOverlayDisplayState(confirmLeaveOverlayDisplayState: Boolean) {
+        isConfirmLeaveOverlayDisplayedStateFlow.value =
+            confirmLeaveOverlayDisplayState
+    }
+
+    fun getIsConfirmLeaveOverlayDisplayedStateFlow(): StateFlow<Boolean> {
+        return isConfirmLeaveOverlayDisplayedStateFlow
     }
 
     fun confirm() {
@@ -22,11 +35,7 @@ internal class ConfirmLeaveOverlayViewModel(
     }
 
     fun cancel() {
-        shouldDisplayConfirmLeaveOverlayStateFlow.value = false
-    }
-
-    fun requestExitConfirmation() {
-        shouldDisplayConfirmLeaveOverlayStateFlow.value = true
+        dispatchAction(action = DisplayAction.IsConfirmLeaveOverlayDisplayed(false))
     }
 
     private fun dispatchAction(action: Action) {

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderView.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.azure.android.communication.ui.R
@@ -20,6 +21,7 @@ internal class InfoHeaderView : ConstraintLayout {
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
 
     private lateinit var floatingHeader: ConstraintLayout
+    private lateinit var headerView: View
     private lateinit var participantNumberText: TextView
     private lateinit var displayParticipantsImageButton: ImageButton
     private lateinit var infoHeaderViewModel: InfoHeaderViewModel
@@ -28,6 +30,7 @@ internal class InfoHeaderView : ConstraintLayout {
     override fun onFinishInflate() {
         super.onFinishInflate()
         floatingHeader = this
+        headerView = findViewById(R.id.azure_communication_ui_call_floating_header)
         participantNumberText =
             findViewById(R.id.azure_communication_ui_call_participant_number_text)
         displayParticipantsImageButton =
@@ -67,6 +70,16 @@ internal class InfoHeaderView : ConstraintLayout {
                                 R.string.azure_communication_ui_call_call_with_n_people,
                                 it
                             )
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            infoHeaderViewModel.getIsConfirmLeaveOverlayDisplayedStateFlow().collect {
+                if (it) {
+                    ViewCompat.setImportantForAccessibility(headerView, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+                } else {
+                    ViewCompat.setImportantForAccessibility(headerView, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES)
                 }
             }
         }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderViewModel.kt
@@ -13,6 +13,8 @@ internal class InfoHeaderViewModel {
 
     private lateinit var numberOfParticipantsFlow: MutableStateFlow<Int>
 
+    private lateinit var isConfirmLeaveOverlayDisplayedStateFlow: MutableStateFlow<Boolean>
+
     private lateinit var timer: Timer
 
     private var displayedOnLaunch = false
@@ -24,7 +26,7 @@ internal class InfoHeaderViewModel {
     }
 
     fun update(
-        numberOfRemoteParticipants: Int,
+        numberOfRemoteParticipants: Int
     ) {
         numberOfParticipantsFlow.value = numberOfRemoteParticipants
         if (!displayedOnLaunch) {
@@ -33,12 +35,21 @@ internal class InfoHeaderViewModel {
         }
     }
 
+    fun updateConfirmLeaveOverlayDisplayState(
+        confirmLeaveOverlayDisplayState: Boolean
+    ) {
+        isConfirmLeaveOverlayDisplayedStateFlow.value =
+            confirmLeaveOverlayDisplayState
+    }
+
     fun init(
         numberOfRemoteParticipants: Int,
+        confirmLeaveOverlayDisplayState: Boolean
     ) {
         timer = Timer()
         displayFloatingHeaderFlow = MutableStateFlow(false)
         numberOfParticipantsFlow = MutableStateFlow(numberOfRemoteParticipants)
+        isConfirmLeaveOverlayDisplayedStateFlow = MutableStateFlow(confirmLeaveOverlayDisplayState)
     }
 
     fun switchFloatingHeader() {
@@ -57,5 +68,9 @@ internal class InfoHeaderViewModel {
             },
             3000
         )
+    }
+
+    fun getIsConfirmLeaveOverlayDisplayedStateFlow(): StateFlow<Boolean> {
+        return isConfirmLeaveOverlayDisplayedStateFlow
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/lobby/LobbyOverlayView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/lobby/LobbyOverlayView.kt
@@ -5,9 +5,12 @@ package com.azure.android.communication.ui.presentation.fragment.calling.lobby
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
 import android.widget.LinearLayout
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import com.azure.android.communication.ui.R
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
@@ -26,6 +29,17 @@ internal class LobbyOverlayView : LinearLayout {
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.getDisplayLobbyOverlayFlow().collect {
                 visibility = if (it) VISIBLE else GONE
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            val lobbyOverlay: View = findViewById(R.id.azure_communication_ui_call_lobby_overlay)
+            viewModel.getIsConfirmLeaveOverlayDisplayedStateFlow().collect {
+                if (it) {
+                    ViewCompat.setImportantForAccessibility(lobbyOverlay, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+                } else {
+                    ViewCompat.setImportantForAccessibility(lobbyOverlay, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES)
+                }
             }
         }
     }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/lobby/LobbyOverlayViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/lobby/LobbyOverlayViewModel.kt
@@ -9,21 +9,35 @@ import kotlinx.coroutines.flow.StateFlow
 
 internal class LobbyOverlayViewModel {
     private lateinit var displayLobbyOverlayFlow: MutableStateFlow<Boolean>
+    private lateinit var isConfirmLeaveOverlayDisplayedStateFlow: MutableStateFlow<Boolean>
 
     fun getDisplayLobbyOverlayFlow(): StateFlow<Boolean> = displayLobbyOverlayFlow
 
     fun init(
         callingState: CallingStatus,
+        confirmLeaveOverlayDisplayState: Boolean
     ) {
         val displayLobbyOverlay = shouldDisplayLobbyOverlay(callingState)
         displayLobbyOverlayFlow = MutableStateFlow(displayLobbyOverlay)
+        isConfirmLeaveOverlayDisplayedStateFlow = MutableStateFlow(confirmLeaveOverlayDisplayState)
     }
 
     fun update(
-        callingState: CallingStatus,
+        callingState: CallingStatus
     ) {
         val displayLobbyOverlay = shouldDisplayLobbyOverlay(callingState)
         displayLobbyOverlayFlow.value = displayLobbyOverlay
+    }
+
+    fun updateConfirmLeaveOverlayDisplayState(
+        confirmLeaveOverlayDisplayState: Boolean
+    ) {
+        isConfirmLeaveOverlayDisplayedStateFlow.value =
+            confirmLeaveOverlayDisplayState
+    }
+
+    fun getIsConfirmLeaveOverlayDisplayedStateFlow(): StateFlow<Boolean> {
+        return isConfirmLeaveOverlayDisplayedStateFlow
     }
 
     private fun shouldDisplayLobbyOverlay(callingStatus: CallingStatus) =

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/localuser/LocalParticipantView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/localuser/LocalParticipantView.kt
@@ -10,6 +10,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.azure.android.communication.ui.R
@@ -127,6 +128,16 @@ internal class LocalParticipantView : ConstraintLayout {
             viewModel.getEnableCameraSwitchFlow().collect {
                 switchCameraButton.isEnabled = it
                 pipSwitchCameraButton.isEnabled = it
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.getIsConfirmLeaveOverlayDisplayedStateFlow().collect {
+                if (it) {
+                    ViewCompat.setImportantForAccessibility(localParticipantPip, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+                } else {
+                    ViewCompat.setImportantForAccessibility(localParticipantPip, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES)
+                }
             }
         }
     }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/localuser/LocalParticipantViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/localuser/LocalParticipantViewModel.kt
@@ -26,6 +26,7 @@ internal class LocalParticipantViewModel(
     private lateinit var displaySwitchCameraButtonFlow: MutableStateFlow<Boolean>
     private lateinit var displayPipSwitchCameraButtonFlow: MutableStateFlow<Boolean>
     private lateinit var enableCameraSwitchFlow: MutableStateFlow<Boolean>
+    private lateinit var isConfirmLeaveOverlayDisplayedStateFlow: MutableStateFlow<Boolean>
 
     fun getVideoStatusFlow(): StateFlow<VideoModel> = videoStatusFlow
     fun getDisplayFullScreenAvatarFlow(): StateFlow<Boolean> = displayFullScreenAvatarFlow
@@ -41,7 +42,7 @@ internal class LocalParticipantViewModel(
         videoStreamID: String?,
         numberOfRemoteParticipants: Int,
         callingState: CallingStatus,
-        cameraDeviceSelectionStatus: CameraDeviceSelectionStatus,
+        cameraDeviceSelectionStatus: CameraDeviceSelectionStatus
     ) {
         val viewMode = getLocalParticipantViewMode(numberOfRemoteParticipants)
         val displayVideo = shouldDisplayVideo(videoStreamID)
@@ -61,6 +62,13 @@ internal class LocalParticipantViewModel(
             cameraDeviceSelectionStatus != CameraDeviceSelectionStatus.SWITCHING
     }
 
+    fun updateConfirmLeaveOverlayDisplayState(
+        confirmLeaveOverlayDisplayState: Boolean
+    ) {
+        isConfirmLeaveOverlayDisplayedStateFlow.value =
+            confirmLeaveOverlayDisplayState
+    }
+
     fun clear() {
         videoStatusFlow.value = VideoModel(false, null, LocalParticipantViewMode.FULL_SCREEN)
     }
@@ -72,6 +80,7 @@ internal class LocalParticipantViewModel(
         numberOfRemoteParticipants: Int,
         callingState: CallingStatus,
         cameraDeviceSelectionStatus: CameraDeviceSelectionStatus,
+        confirmLeaveOverlayDisplayState: Boolean
     ) {
 
         val viewMode = getLocalParticipantViewMode(numberOfRemoteParticipants)
@@ -92,10 +101,15 @@ internal class LocalParticipantViewModel(
         enableCameraSwitchFlow = MutableStateFlow(
             cameraDeviceSelectionStatus != CameraDeviceSelectionStatus.SWITCHING
         )
+        isConfirmLeaveOverlayDisplayedStateFlow = MutableStateFlow(confirmLeaveOverlayDisplayState)
     }
 
     fun switchCamera() {
         dispatch(LocalParticipantAction.CameraSwitchTriggered())
+    }
+
+    fun getIsConfirmLeaveOverlayDisplayedStateFlow(): StateFlow<Boolean> {
+        return isConfirmLeaveOverlayDisplayedStateFlow
     }
 
     private fun shouldDisplayVideo(videoStreamID: String?) = videoStreamID != null

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/participant/grid/ParticipantGridView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/participant/grid/ParticipantGridView.kt
@@ -9,9 +9,11 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
 import android.widget.GridLayout
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.azure.android.communication.calling.VideoStreamRenderer
+import com.azure.android.communication.ui.R
 import com.azure.android.communication.ui.presentation.VideoViewManager
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -65,6 +67,17 @@ internal class ParticipantGridView : GridLayout {
             participantGridViewModel.getRemoteParticipantsUpdateStateFlow().collect {
                 post {
                     updateGrid(it)
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            participantGridViewModel.getIsConfirmLeaveOverlayDisplayedStateFlow().collect {
+                val videoView: View = super.findViewById(R.id.azure_communication_ui_call_participant_container)
+                if (it) {
+                    ViewCompat.setImportantForAccessibility(videoView, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+                } else {
+                    ViewCompat.setImportantForAccessibility(videoView, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES)
                 }
             }
         }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/participant/grid/ParticipantGridViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/participant/grid/ParticipantGridViewModel.kt
@@ -16,9 +16,18 @@ internal class ParticipantGridViewModel(private val participantGridCellViewModel
     private var displayedRemoteParticipantsViewModelMap =
         mutableMapOf<String, ParticipantGridCellViewModel>()
 
+    private lateinit var isConfirmLeaveOverlayDisplayedStateFlow: MutableStateFlow<Boolean>
+
     private var updateVideoStreamsCallback: ((List<Pair<String, String>>) -> Unit)? = null
     private var remoteParticipantStateModifiedTimeStamp: Number = 0
     private val maxRemoteParticipantSize = 6
+
+    fun init(
+        confirmLeaveOverlayDisplayState: Boolean
+    ) {
+        isConfirmLeaveOverlayDisplayedStateFlow =
+            MutableStateFlow(confirmLeaveOverlayDisplayState)
+    }
 
     fun clear() {
         remoteParticipantStateModifiedTimeStamp = 0
@@ -64,6 +73,17 @@ internal class ParticipantGridViewModel(private val participantGridCellViewModel
         updateRemoteParticipantsVideoStreams(remoteParticipantsMapSorted)
 
         updateDisplayedParticipants(remoteParticipantsMapSorted.toMutableMap())
+    }
+
+    fun updateConfirmLeaveOverlayDisplayState(
+        confirmLeaveOverlayDisplayState: Boolean
+    ) {
+        isConfirmLeaveOverlayDisplayedStateFlow.value =
+            confirmLeaveOverlayDisplayState
+    }
+
+    fun getIsConfirmLeaveOverlayDisplayedStateFlow(): StateFlow<Boolean> {
+        return isConfirmLeaveOverlayDisplayedStateFlow
     }
 
     private fun getParticipantSharingScreen(

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/action/DisplayAction.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/action/DisplayAction.kt
@@ -1,0 +1,6 @@
+package com.azure.android.communication.ui.redux.action
+
+internal sealed class DisplayAction :
+    Action {
+    class IsConfirmLeaveOverlayDisplayed(val isConfirmLeaveOverlayDisplayed: Boolean) : DisplayAction()
+}

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/middleware/CallingMiddleware.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/middleware/CallingMiddleware.kt
@@ -9,6 +9,7 @@ import com.azure.android.communication.ui.redux.Middleware
 import com.azure.android.communication.ui.redux.Store
 import com.azure.android.communication.ui.redux.action.Action
 import com.azure.android.communication.ui.redux.action.CallingAction
+import com.azure.android.communication.ui.redux.action.DisplayAction
 import com.azure.android.communication.ui.redux.action.ErrorAction
 import com.azure.android.communication.ui.redux.action.LifecycleAction
 import com.azure.android.communication.ui.redux.action.LocalParticipantAction
@@ -73,6 +74,9 @@ internal class CallingMiddlewareImpl(
                 }
                 is ErrorAction.EmergencyExit -> {
                     callingMiddlewareActionHandler.exit(store)
+                }
+                is DisplayAction.IsConfirmLeaveOverlayDisplayed -> {
+                    callingMiddlewareActionHandler.updateConfirmLeaveOverlayDisplay(store)
                 }
             }
             next(action)

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandler.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandler.kt
@@ -8,6 +8,7 @@ import com.azure.android.communication.ui.error.CallCompositeError
 import com.azure.android.communication.ui.error.FatalError
 import com.azure.android.communication.ui.redux.Store
 import com.azure.android.communication.ui.redux.action.CallingAction
+import com.azure.android.communication.ui.redux.action.DisplayAction
 import com.azure.android.communication.ui.redux.action.ErrorAction
 import com.azure.android.communication.ui.redux.action.LifecycleAction
 import com.azure.android.communication.ui.redux.action.LocalParticipantAction
@@ -43,6 +44,7 @@ internal interface CallingMiddlewareActionHandler {
     fun turnMicOn(store: Store<ReduxState>)
     fun turnMicOff(store: Store<ReduxState>)
     fun onCameraPermissionIsSet(store: Store<ReduxState>)
+    fun updateConfirmLeaveOverlayDisplay(store: Store<ReduxState>)
     fun exit(store: Store<ReduxState>)
     fun dispose()
 }
@@ -267,6 +269,19 @@ internal class CallingMiddlewareActionHandlerImpl(
                         )
                     )
                 }
+            }
+        }
+    }
+
+    override fun updateConfirmLeaveOverlayDisplay(store: Store<ReduxState>) {
+        coroutineScope.launch {
+            callingService.getIsConfirmLeaveOverlayDisplayedSharedFlow().collect {
+                val action = if (it) {
+                    DisplayAction.IsConfirmLeaveOverlayDisplayed(true)
+                } else {
+                    DisplayAction.IsConfirmLeaveOverlayDisplayed(false)
+                }
+                store.dispatch(action)
             }
         }
     }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/reducer/AppStateReducer.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/reducer/AppStateReducer.kt
@@ -14,6 +14,7 @@ internal class AppStateReducer(
     private val lifecycleReducer: LifecycleReducer,
     private val errorReducer: ErrorReducer,
     private val navigationReducer: NavigationReducer,
+    private val displayReducer: DisplayReducer
 ) :
     Reducer<AppReduxState> {
     override fun reduce(state: AppReduxState, action: Action): AppReduxState {
@@ -39,6 +40,7 @@ internal class AppStateReducer(
         appState.lifecycleState = lifecycleReducer.reduce(state.lifecycleState, action)
         appState.errorState = errorReducer.reduce(state.errorState, action)
         appState.navigationState = navigationReducer.reduce(state.navigationState, action)
+        appState.displayState = displayReducer.reduce(state.displayState, action)
 
         return appState
     }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/reducer/DisplayReducer.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/reducer/DisplayReducer.kt
@@ -1,0 +1,19 @@
+package com.azure.android.communication.ui.redux.reducer
+
+import com.azure.android.communication.ui.redux.action.Action
+import com.azure.android.communication.ui.redux.action.DisplayAction
+import com.azure.android.communication.ui.redux.state.DisplayState
+
+internal interface DisplayReducer : Reducer<DisplayState>
+
+internal class DisplayReducerImpl :
+    DisplayReducer {
+    override fun reduce(state: DisplayState, action: Action): DisplayState {
+        return when (action) {
+            is DisplayAction.IsConfirmLeaveOverlayDisplayed -> {
+                state.copy(confirmLeaveOverlayDisplayState = action.isConfirmLeaveOverlayDisplayed)
+            }
+            else -> state
+        }
+    }
+}

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/state/AppReduxState.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/state/AppReduxState.kt
@@ -34,4 +34,6 @@ internal class AppReduxState(displayName: String?) : ReduxState {
     override var errorState: ErrorState = ErrorState(fatalError = null, callStateError = null)
 
     override var navigationState: NavigationState = NavigationState(NavigationStatus.SETUP)
+
+    override var displayState: DisplayState = DisplayState(false)
 }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/state/DisplayState.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/state/DisplayState.kt
@@ -1,0 +1,5 @@
+package com.azure.android.communication.ui.redux.state
+
+internal data class DisplayState(
+    val confirmLeaveOverlayDisplayState: Boolean
+)

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/state/ReduxState.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/state/ReduxState.kt
@@ -11,4 +11,5 @@ internal interface ReduxState {
     var lifecycleState: LifecycleState
     var errorState: ErrorState
     var navigationState: NavigationState
+    var displayState: DisplayState
 }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/service/calling/CallingService.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/service/calling/CallingService.kt
@@ -53,6 +53,7 @@ internal class CallingService(
     private val coroutineScope = CoroutineScope((coroutineContextProvider.Default))
     private var callInfoModelSharedFlow = MutableSharedFlow<CallInfoModel>()
     private var callingStatus: CallingStatus = CallingStatus.NONE
+    private var isConfirmLeaveOverlayDisplayedSharedFlow = MutableSharedFlow<Boolean>()
 
     fun turnCameraOn(): CompletableFuture<String> {
         return callingSDKWrapper.turnOnVideoAsync().thenApply { stream ->
@@ -103,6 +104,10 @@ internal class CallingService(
 
     fun getIsTranscribingSharedFlow(): Flow<Boolean> {
         return isTranscribingSharedFlow
+    }
+
+    fun getIsConfirmLeaveOverlayDisplayedSharedFlow(): Flow<Boolean> {
+        return isConfirmLeaveOverlayDisplayedSharedFlow
     }
 
     fun endCall(): CompletableFuture<Void> {

--- a/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerViewModelUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerViewModelUnitTest.kt
@@ -38,7 +38,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -75,7 +75,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -112,7 +112,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -150,7 +150,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -193,7 +193,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -236,7 +236,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -280,7 +280,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -324,7 +324,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -372,7 +372,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -420,7 +420,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -469,7 +469,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -518,7 +518,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -561,7 +561,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -605,7 +605,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -648,7 +648,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -692,7 +692,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -736,7 +736,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -780,7 +780,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -824,7 +824,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -868,7 +868,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -917,7 +917,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -966,7 +966,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1015,7 +1015,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1064,7 +1064,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1112,7 +1112,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1161,7 +1161,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1209,7 +1209,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1258,7 +1258,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1307,7 +1307,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1356,7 +1356,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1405,7 +1405,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1454,7 +1454,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1503,7 +1503,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1552,7 +1552,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1601,7 +1601,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {
@@ -1650,7 +1650,7 @@ internal class BannerViewModelUnitTest {
             // arrange
             val initialCallingState = CallingState(CallingStatus.CONNECTED)
             val bannerViewModel = BannerViewModel()
-            bannerViewModel.init(initialCallingState)
+            bannerViewModel.init(initialCallingState, false)
 
             val resultBannerInfoTypeStateFlow = mutableListOf<BannerInfoType>()
             val flowJob = launch {

--- a/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/controlbar/ControlBarViewModelUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/controlbar/ControlBarViewModelUnitTest.kt
@@ -112,7 +112,8 @@ internal class ControlBarViewModelUnitTest {
             callingViewModel.init(
                 permissionState,
                 cameraState,
-                AudioState(AudioOperationalStatus.OFF, audioDeviceState)
+                AudioState(AudioOperationalStatus.OFF, audioDeviceState),
+                false
             )
 
             val expectedAudioOperationalStatus1 = AudioOperationalStatus.ON
@@ -184,7 +185,8 @@ internal class ControlBarViewModelUnitTest {
             callingViewModel.init(
                 initialPermissionState,
                 cameraState,
-                AudioState(AudioOperationalStatus.OFF, audioDeviceState)
+                AudioState(AudioOperationalStatus.OFF, audioDeviceState),
+                false
             )
 
             val flowJob = launch {
@@ -258,7 +260,8 @@ internal class ControlBarViewModelUnitTest {
             callingViewModel.init(
                 permissionState,
                 initialCameraState,
-                AudioState(AudioOperationalStatus.OFF, audioDeviceState)
+                AudioState(AudioOperationalStatus.OFF, audioDeviceState),
+                false
             )
 
             val resultListFromCameraStateFlow = mutableListOf<ControlBarViewModel.CameraModel>()

--- a/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderViewModelUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderViewModelUnitTest.kt
@@ -47,7 +47,7 @@ internal class InfoHeaderViewModelUnitTest {
             )
 
             val floatingHeaderViewModel = InfoHeaderViewModel()
-            floatingHeaderViewModel.init(expectedParticipantMap.count())
+            floatingHeaderViewModel.init(expectedParticipantMap.count(), false)
 
             val resultListFromNumberOfParticipantsFlow =
                 mutableListOf<Int>()

--- a/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/lobby/LobbyOverlayViewModelTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/lobby/LobbyOverlayViewModelTest.kt
@@ -28,6 +28,7 @@ internal class LobbyOverlayViewModelTest {
             val viewModel = LobbyOverlayViewModel()
             viewModel.init(
                 CallingStatus.CONNECTED,
+                false
             )
 
             val modelFlow = mutableListOf<Boolean>()

--- a/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/localuser/LocalParticipantGridCellViewModelTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/presentation/fragment/calling/localuser/LocalParticipantGridCellViewModelTest.kt
@@ -38,7 +38,8 @@ internal class LocalParticipantGridCellViewModelTest {
                 videoStreamID = null,
                 numberOfRemoteParticipants = 0,
                 CallingStatus.CONNECTED,
-                CameraDeviceSelectionStatus.FRONT
+                CameraDeviceSelectionStatus.FRONT,
+                false
             )
 
             val isMutedFlow = mutableListOf<Boolean>()
@@ -105,7 +106,8 @@ internal class LocalParticipantGridCellViewModelTest {
                 videoStreamID = null,
                 numberOfRemoteParticipants = 0,
                 CallingStatus.CONNECTED,
-                CameraDeviceSelectionStatus.FRONT
+                CameraDeviceSelectionStatus.FRONT,
+                false
             )
 
             val displayNameFlow = mutableListOf<String?>()
@@ -143,7 +145,8 @@ internal class LocalParticipantGridCellViewModelTest {
                 videoStreamID = null,
                 numberOfRemoteParticipants = 0,
                 CallingStatus.CONNECTED,
-                CameraDeviceSelectionStatus.FRONT
+                CameraDeviceSelectionStatus.FRONT,
+                false
             )
 
             val modelFlow = mutableListOf<LocalParticipantViewModel.VideoModel>()
@@ -214,7 +217,8 @@ internal class LocalParticipantGridCellViewModelTest {
                 videoStreamID = videoStreamID,
                 numberOfRemoteParticipants = 0,
                 CallingStatus.CONNECTED,
-                CameraDeviceSelectionStatus.FRONT
+                CameraDeviceSelectionStatus.FRONT,
+                false
             )
 
             val modelFlow = mutableListOf<Boolean>()
@@ -283,7 +287,8 @@ internal class LocalParticipantGridCellViewModelTest {
                 videoStreamID = videoStreamID,
                 numberOfRemoteParticipants = 0,
                 CallingStatus.CONNECTED,
-                CameraDeviceSelectionStatus.FRONT
+                CameraDeviceSelectionStatus.FRONT,
+                false
             )
 
             val modelFlow = mutableListOf<Boolean>()

--- a/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/redux/reducer/AppReduxStateReducerUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/redux/reducer/AppReduxStateReducerUnitTest.kt
@@ -51,6 +51,9 @@ internal class AppReduxStateReducerUnitTest {
     @Mock
     private lateinit var mockNavigationReducerImpl: NavigationReducerImpl
 
+    @Mock
+    private lateinit var mockDisplayReducerImpl: DisplayReducerImpl
+
     @Test
     fun appStateReducer_reduce_when_invoked_then_callAllReducers() {
 
@@ -63,7 +66,8 @@ internal class AppReduxStateReducerUnitTest {
                 mockPermissionStateReducerImplementation,
                 mockLifecycleReducer,
                 mockErrorReducer,
-                mockNavigationReducerImpl
+                mockNavigationReducerImpl,
+                mockDisplayReducerImpl
             )
         val action = NavigationAction.CallLaunched()
         val state = AppReduxState("")
@@ -126,6 +130,13 @@ internal class AppReduxStateReducerUnitTest {
                 action
             )
         ).thenReturn(state.navigationState)
+
+        Mockito.`when`(
+            mockDisplayReducerImpl.reduce(
+                state.displayState,
+                action
+            )
+        ).thenReturn(state.displayState)
 
         // act
         reducer.reduce(state, action)


### PR DESCRIPTION
## Purpose
When confirm leave overlay is up, Talkback should focus on the buttons on the overlay. 
When confirm leave overlay is up and swiping left or right to navigate the UI elements, Talkback should not focus on the UI elements underneath.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Turn on screen reader(eg. talkback on pixel)
run the app to join group call with remote participants
using swipe to focus on leave call button on the bottom bar
double click to open confirm leave overlay
verify: 1. the first element being focused is blue button on the overlay.
            2. swiping left or right, screen reader should not focus on any UI elements under confirm leave overlay
