### PR TITLE
[Features] debounce timer on UI state updates

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/AppStore.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/AppStore.kt
@@ -56,7 +56,6 @@ internal class AppStore<S>(
     }
 
     // Post the update to the StateFlow in a debounced way (to reduce UI updates)
-
     private fun debouncePostUpdate() {
         debounceTimer?.cancel()
         debounceTimer = Timer()

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/Store.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/redux/Store.kt
@@ -4,11 +4,11 @@
 package com.azure.android.communication.ui.redux
 
 import com.azure.android.communication.ui.redux.action.Action
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 internal interface Store<S> {
     fun dispatch(action: Action)
-    fun getStateFlow(): MutableStateFlow<S>
+    fun getStateFlow(): StateFlow<S>
     fun getCurrentState(): S
     fun end()
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The store stateflow is behind a debounce now (of 1ms) so that rapid dispatches don't trigger multiple UI updates

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
App should run as normal
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
