### PR TITLE
[Refactor] Talkback tells users to dismiss participant list

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/participantlist/ParticipantListView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/participantlist/ParticipantListView.kt
@@ -4,6 +4,7 @@
 package com.azure.android.communication.ui.presentation.fragment.calling.participantlist
 
 import android.content.Context
+import android.view.accessibility.AccessibilityManager
 import android.widget.RelativeLayout
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
@@ -25,6 +26,7 @@ internal class ParticipantListView(
 
     private lateinit var participantListDrawer: DrawerDialog
     private lateinit var bottomCellAdapter: BottomCellAdapter
+    private lateinit var accessibilityManager: AccessibilityManager
 
     init {
         inflate(context, R.layout.azure_communication_ui_listview, this)
@@ -72,6 +74,8 @@ internal class ParticipantListView(
     }
 
     private fun initializeParticipantListDrawer() {
+        accessibilityManager =
+            context?.applicationContext?.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
         participantListDrawer = DrawerDialog(context, DrawerDialog.BehaviorType.BOTTOM)
         participantListDrawer.setOnDismissListener {
             viewModel.closeParticipantList()
@@ -154,6 +158,10 @@ internal class ParticipantListView(
         return BottomCellItem(
             null,
             displayName,
+            displayName + viewModel.getLocalizationProvider().getLocalizedString(
+                context,
+                R.string.azure_communication_ui_calling_view_participant_list_dismiss_list
+            ),
             ContextCompat.getDrawable(
                 context,
                 R.drawable.azure_communication_ui_ic_fluent_mic_off_24_regular
@@ -166,6 +174,9 @@ internal class ParticipantListView(
                 ),
             isMuted
         ) {
+            if (accessibilityManager.isEnabled) {
+                participantListDrawer.dismiss()
+            }
         }
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
@@ -104,6 +104,7 @@ internal class AudioDeviceListView(
                         }
 
                     ),
+                    null,
                     ContextCompat.getDrawable(
                         context,
                         R.drawable.ms_ic_checkmark_24_filled
@@ -122,6 +123,7 @@ internal class AudioDeviceListView(
                         R.drawable.azure_communication_ui_ic_fluent_speaker_2_24_filled_composite_button_enabled
                     ),
                     getLocalizedString(R.string.azure_communication_ui_audio_device_drawer_speaker),
+                    null,
                     ContextCompat.getDrawable(
                         context,
                         R.drawable.ms_ic_checkmark_24_filled
@@ -146,6 +148,7 @@ internal class AudioDeviceListView(
                             R.drawable.azure_communication_ui_ic_fluent_speaker_bluetooth_24_regular
                         ),
                         viewModel.audioStateFlow.value.bluetoothState.deviceName,
+                        null,
                         ContextCompat.getDrawable(
                             context,
                             R.drawable.ms_ic_checkmark_24_filled

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/utilities/BottomCellItem.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/utilities/BottomCellItem.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.Drawable
 internal data class BottomCellItem(
     var icon: Drawable?,
     var title: String?,
+    var contentDescription: String?,
     var accessoryImage: Drawable?,
     var accessoryColor: Int?,
     var accessoryImageDescription: String,

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/utilities/BottomCellViewHolder.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/utilities/BottomCellViewHolder.kt
@@ -7,6 +7,9 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.core.view.AccessibilityDelegateCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.azure.android.communication.ui.R
 import com.microsoft.fluentui.persona.AvatarView
@@ -26,15 +29,26 @@ internal class BottomCellViewHolder(itemView: View) : RecyclerView.ViewHolder(it
     }
 
     fun setCellData(bottomCellItem: BottomCellItem) {
+        title.text = bottomCellItem.title
         if (bottomCellItem.icon == null) {
+            ViewCompat.setAccessibilityDelegate(
+                itemView,
+                object : AccessibilityDelegateCompat() {
+                    override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfoCompat) {
+                        super.onInitializeAccessibilityNodeInfo(host, info)
+                        info.removeAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_CLICK)
+                        info.isClickable = false
+                    }
+                }
+            )
             imageView.visibility = View.GONE
             avatarView.visibility = View.VISIBLE
             avatarView.name = bottomCellItem.title ?: ""
+            title.contentDescription = bottomCellItem.contentDescription
         } else {
             imageView.setImageDrawable(bottomCellItem.icon)
             avatarView.visibility = View.GONE
         }
-        title.text = bottomCellItem.title
         accessoryImage.setImageDrawable(bottomCellItem.accessoryImage)
         if (bottomCellItem.accessoryColor != null) {
             accessoryImage.setColorFilter(

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values/azure_communication_ui_strings.xml
@@ -41,6 +41,7 @@
     <string name="azure_communication_ui_calling_view_overlay_leave_call">Leave call</string>
     <string name="azure_communication_ui_calling_view_overlay_cancel">Cancel</string>
     <string name="azure_communication_ui_calling_view_participant_list_open_accessibility_label">Open Participant List</string>
+    <string name="azure_communication_ui_calling_view_participant_list_dismiss_list" translatable="false">Double tap to dismiss Participant list</string>
     <string name="azure_communication_ui_calling_view_participant_list_muted_accessibility_label">Muted</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Hang Up</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Toggle Video</string>


### PR DESCRIPTION
## Purpose
With this refactoring change, when participant list is open, when focus on any participant list item, talkback tells user to "double tap to dismiss participant list".

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Turn on Talkback, join the call, navigate to open participant list, swipe to focus on any item of participant list. verify if Talkback can read "double tap to dismiss participant list"