### PR TITLE
[Bug] empty banner view is displayed for stopped transcription and audio recording on screen rotate

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerView.kt
@@ -25,7 +25,6 @@ internal class BannerView : ConstraintLayout {
     private lateinit var bannerView: View
     private lateinit var bannerText: TextView
     private lateinit var bannerCloseButton: ImageButton
-
     private lateinit var viewModel: BannerViewModel
 
     fun start(
@@ -65,7 +64,16 @@ internal class BannerView : ConstraintLayout {
 
     private fun updateNoticeBox(bannerInfoType: BannerInfoType) {
         if (bannerInfoType != BannerInfoType.BLANK) {
+            viewModel.setDisplayedBannerType(bannerInfoType)
             bannerText.text = getBannerInfo(bannerInfoType)
+            bannerText.setOnClickListener(getBannerClickDestination(bannerInfoType))
+            announceForAccessibility(bannerText.text)
+        }
+        // Below code helps to reset banner on screen rotate. When recording and transcription being saved is displayed
+        // and screen is rotated, blank banner is displayed.
+        // We can not remove reset state in view model on stop as that cause incorrect message order
+        else if (bannerText.text.isNullOrBlank() && viewModel.getDisplayedBannerType() != BannerInfoType.BLANK) {
+            bannerText.text = getBannerInfo(viewModel.getDisplayedBannerType())
             bannerText.setOnClickListener(getBannerClickDestination(bannerInfoType))
             announceForAccessibility(bannerText.text)
         }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerView.kt
@@ -69,7 +69,7 @@ internal class BannerView : ConstraintLayout {
             bannerText.setOnClickListener(getBannerClickDestination(bannerInfoType))
             announceForAccessibility(bannerText.text)
         }
-        // Below code helps to reset banner on screen rotate. When recording and transcription being saved is displayed
+        // Below code helps to display banner message on screen rotate. When recording and transcription being saved is displayed
         // and screen is rotated, blank banner is displayed.
         // We can not remove reset state in view model on stop as that cause incorrect message order
         else if (bannerText.text.isNullOrBlank() && viewModel.getDisplayedBannerType() != BannerInfoType.BLANK) {

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerViewModel.kt
@@ -47,10 +47,6 @@ internal class BannerViewModel(private val localizationProvider: LocalizationPro
         isLobbyOverlayDisplayedFlow.value = isLobbyOverlayDisplayed(callingStatus)
     }
 
-    fun stop(bannerInfoType: BannerInfoType) {
-        displayedBannerType = bannerInfoType
-    }
-
     fun update(callingState: CallingState) {
         val currentBannerInfoType = bannerInfoTypeStateFlow.value
         val newBannerInfoType =

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/banner/BannerViewModel.kt
@@ -18,6 +18,8 @@ internal class BannerViewModel(private val localizationProvider: LocalizationPro
     private var recordingState: ComplianceState = ComplianceState.OFF
     private var transcriptionState: ComplianceState = ComplianceState.OFF
 
+    private var displayedBannerType: BannerInfoType = BannerInfoType.BLANK
+
     fun getIsLobbyOverlayDisplayedFlow(): StateFlow<Boolean> = isLobbyOverlayDisplayedFlow
 
     fun getBannerInfoTypeStateFlow(): StateFlow<BannerInfoType> {
@@ -32,6 +34,8 @@ internal class BannerViewModel(private val localizationProvider: LocalizationPro
         return localizationProvider
     }
 
+    fun getDisplayedBannerType() = displayedBannerType
+
     fun init(callingState: CallingState) {
         bannerInfoTypeStateFlow = MutableStateFlow(
             createBannerInfoType(callingState.isRecording, callingState.isTranscribing)
@@ -41,6 +45,31 @@ internal class BannerViewModel(private val localizationProvider: LocalizationPro
 
     fun updateIsLobbyOverlayDisplayed(callingStatus: CallingStatus) {
         isLobbyOverlayDisplayedFlow.value = isLobbyOverlayDisplayed(callingStatus)
+    }
+
+    fun stop(bannerInfoType: BannerInfoType) {
+        displayedBannerType = bannerInfoType
+    }
+
+    fun update(callingState: CallingState) {
+        val currentBannerInfoType = bannerInfoTypeStateFlow.value
+        val newBannerInfoType =
+            createBannerInfoType(callingState.isRecording, callingState.isTranscribing)
+
+        if (newBannerInfoType != currentBannerInfoType) {
+            bannerInfoTypeStateFlow.value = newBannerInfoType
+            shouldShowBannerStateFlow.value = true
+        }
+    }
+
+    fun setDisplayedBannerType(bannerInfoType: BannerInfoType) {
+        displayedBannerType = bannerInfoType
+    }
+
+    fun dismissBanner() {
+        shouldShowBannerStateFlow.value = false
+        displayedBannerType = BannerInfoType.BLANK
+        resetStoppedStates()
     }
 
     private fun createBannerInfoType(
@@ -109,22 +138,6 @@ internal class BannerViewModel(private val localizationProvider: LocalizationPro
         } else {
             return BannerInfoType.BLANK
         }
-    }
-
-    fun update(callingState: CallingState) {
-        val currentBannerInfoType = bannerInfoTypeStateFlow.value
-        val newBannerInfoType =
-            createBannerInfoType(callingState.isRecording, callingState.isTranscribing)
-
-        if (newBannerInfoType != currentBannerInfoType) {
-            bannerInfoTypeStateFlow.value = newBannerInfoType
-            shouldShowBannerStateFlow.value = true
-        }
-    }
-
-    fun dismissBanner() {
-        shouldShowBannerStateFlow.value = false
-        resetStoppedStates()
     }
 
     private fun resetStoppedStates() {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The fix helps to display banner on screen rotate. When recording and transcription being saved is displayed and screen is rotated, blank banner is displayed. We can not remove reset state in view model on stop as that cause incorrect message order

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Rotate screen when banner is displayed for start/stop recording scenario
* please compare with no changes to make sure message order is preserved