### PR TITLE
[Bug] Fixed title bar focus order

### DIFF
--- a/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/CallingCompositeAudioDeviceListTest.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/CallingCompositeAudioDeviceListTest.kt
@@ -4,6 +4,7 @@ package com.azure.android.communication.ui.callingcompositedemoapp
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import androidx.test.filters.SdkSuppress
 import com.azure.android.communication.ui.callingcompositedemoapp.robots.HomeScreenRobot
 import com.azure.android.communication.ui.callingcompositedemoapp.robots.SetupScreenRobot
 import com.azure.android.communication.ui.callingcompositedemoapp.util.TestFixture
@@ -14,6 +15,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class CallingCompositeAudioDeviceListTest : BaseUiTest() {
 
+    @SdkSuppress(minSdkVersion = 23, maxSdkVersion = 29)
     @Test
     fun selectDefaultAudioDevice() {
         joinGroupSetupScreen()
@@ -21,7 +23,7 @@ class CallingCompositeAudioDeviceListTest : BaseUiTest() {
             .verifyIsAndroidAudioDevice()
             .navigateUpFromSetupScreen()
     }
-
+    @SdkSuppress(minSdkVersion = 23, maxSdkVersion = 29)
     @Test
     fun selectSpeakerAudioDevice() {
         joinGroupSetupScreen()

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/matchers/BottomCellViewHolderMatcher.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/matchers/BottomCellViewHolderMatcher.kt
@@ -5,7 +5,6 @@ package com.azure.android.communication.ui.callingcompositedemoapp.matchers
 import android.content.res.Resources
 import android.graphics.drawable.Drawable
 import android.view.View
-import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.DrawableRes
@@ -29,7 +28,7 @@ class BottomCellViewHolderMatcher(
 
     override fun matchesSafely(item: RecyclerView.ViewHolder?): Boolean {
         val holderRoot = item?.itemView ?: return false
-        val checkMark: ImageButton = holderRoot.findViewById(R.id.cell_check_mark)
+        val checkMark: ImageView = holderRoot.findViewById(R.id.cell_check_mark)
         val audioDeviceTextView: TextView = holderRoot.findViewById(R.id.cell_text)
         val audioDeviceIcon: ImageView = holderRoot.findViewById(R.id.cell_icon)
 

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/robots/ScreenRobot.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/robots/ScreenRobot.kt
@@ -20,6 +20,16 @@ abstract class ScreenRobot<T : ScreenRobot<T>> {
         return viewInteraction
     }
 
+    fun waitUntilAllViewIdIsAreDisplayed(
+        @IdRes viewId: Int,
+        idlingResource: ViewIsDisplayedResource = ViewIsDisplayedResource(),
+    ): ViewInteraction {
+        val viewInteraction = idlingResource.waitUntilViewIsDisplayed {
+            UiTestUtils.checkAllViewIdsAreDisplayed(viewId)
+        }
+        return viewInteraction
+    }
+
     fun waitUntilViewIdIsDisplayed(
         @IdRes viewId: Int,
         idlingResource: ViewIsDisplayedResource = ViewIsDisplayedResource(),

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/robots/SetupScreenRobot.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/robots/SetupScreenRobot.kt
@@ -58,7 +58,7 @@ class SetupScreenRobot : ScreenRobot<SetupScreenRobot>() {
     }
 
     private fun selectAudioDevice(@DrawableRes iconId: Int, text: String, isSelected: Boolean) {
-        val audioDeviceList = waitUntilViewIdIsDisplayed(R.id.bottom_drawer_table)
+        val audioDeviceList = waitUntilAllViewIdIsAreDisplayed(R.id.cell_text)
         UiTestUtils.clickBottomCellViewHolder(R.id.bottom_drawer_table, iconId, text, isSelected)
     }
 
@@ -67,6 +67,14 @@ class SetupScreenRobot : ScreenRobot<SetupScreenRobot>() {
             val viewDisplayResource = ViewIsDisplayedResource()
             waitUntilViewIdIsDisplayed(
                 R.id.azure_communication_ui_setup_camera_button,
+                viewDisplayResource
+            )
+            waitUntilViewIdIsDisplayed(
+                R.id.azure_communication_ui_setup_audio_button,
+                viewDisplayResource
+            )
+            waitUntilViewIdIsDisplayed(
+                R.id.azure_communication_ui_setup_audio_device_button,
                 viewDisplayResource
             )
 

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/util/UiTestUtils.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/util/UiTestUtils.kt
@@ -50,6 +50,10 @@ object UiTestUtils {
         onView(withId(viewId)).check(ViewAssertions.matches(isDisplayed()))
 
     @Throws(NoMatchingViewException::class)
+    fun checkAllViewIdsAreDisplayed(@IdRes viewId: Int): ViewInteraction =
+        onView(allOf(withId(viewId), isDisplayed()))
+
+    @Throws(NoMatchingViewException::class)
     fun checkViewIdIsNotDisplayed(@IdRes viewId: Int): ViewInteraction =
         onView(withId(viewId)).check(ViewAssertions.matches(not(isDisplayed())))
 

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/setup/SetupFragment.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/setup/SetupFragment.kt
@@ -4,11 +4,7 @@
 package com.azure.android.communication.ui.presentation.fragment.setup
 
 import android.os.Bundle
-import android.text.Spannable
-import android.text.SpannableString
-import android.text.style.ForegroundColorSpan
 import android.view.View
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
@@ -101,15 +97,6 @@ internal class SetupFragment :
     }
 
     private fun setActionBarTitle() {
-        val mSpannableText = SpannableString(getString(R.string.azure_communication_ui_call_setup_action_bar_title))
-
-        mSpannableText.setSpan(
-            ForegroundColorSpan(ContextCompat.getColor(requireContext(), R.color.azure_communication_ui_color_action_bar_text)),
-            0,
-            mSpannableText.length,
-            Spannable.SPAN_INCLUSIVE_INCLUSIVE
-        )
-
-        activity?.title = mSpannableText
+        activity?.title = getString(R.string.azure_communication_ui_call_setup_action_bar_title)
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/main/res/layout/azure_communication_ui_fragment_setup.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/layout/azure_communication_ui_fragment_setup.xml
@@ -106,7 +106,7 @@
 
         <com.azure.android.communication.ui.presentation.fragment.setup.components.SetupControlBarView
             android:id="@+id/azure_communication_ui_setup_buttons"
-            android:layout_width="330dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="20dp"
             android:orientation="horizontal"
@@ -117,8 +117,8 @@
             <com.azure.android.communication.ui.presentation.fragment.setup.components.SetupButton
                 android:id="@+id/azure_communication_ui_setup_camera_button"
                 style="@style/Widget.FluentUI.Button.Borderless"
-                android:layout_width="85dp"
-                android:layout_height="85dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:background="@android:color/transparent"
                 android:drawableTop="@drawable/azure_communication_ui_toggle_selector_camera_for_setup"
@@ -136,8 +136,8 @@
             <com.azure.android.communication.ui.presentation.fragment.setup.components.SetupButton
                 android:id="@+id/azure_communication_ui_setup_audio_button"
                 style="@style/Widget.FluentUI.Button.Borderless"
-                android:layout_width="85dp"
-                android:layout_height="85dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:background="@android:color/transparent"
                 android:drawableTop="@drawable/azure_communication_ui_toggle_selector_mic_for_setup"
@@ -155,8 +155,8 @@
             <com.azure.android.communication.ui.presentation.fragment.setup.components.AudioDeviceSetupButton
                 android:id="@+id/azure_communication_ui_setup_audio_device_button"
                 style="@style/Widget.FluentUI.Button.Borderless"
-                android:layout_width="85dp"
-                android:layout_height="85dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:background="@android:color/transparent"
                 android:drawableTop="@drawable/azure_communication_ui_toggle_selector_device_for_setup"

--- a/azure-communication-ui/azure-communication-ui/src/main/res/layout/azure_communication_ui_fragment_setup.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/layout/azure_communication_ui_fragment_setup.xml
@@ -237,7 +237,7 @@
                 android:layout_width="24dp"
                 android:layout_height="0dp"
                 android:layout_marginRight="8dp"
-                android:indeterminateTint="@color/azure_communication_ui_color_com_primary"
+                android:indeterminateTint="@color/azure_communication_ui_color_primary"
                 android:visibility="gone"
                 app:layout_constraintBottom_toBottomOf="@+id/azure_communication_ui_setup_start_call_joining_text"
                 app:layout_constraintRight_toLeftOf="@+id/azure_communication_ui_setup_start_call_joining_text"

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-night/azure_communication_ui_colors.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-night/azure_communication_ui_colors.xml
@@ -3,7 +3,6 @@
    Licensed under the MIT License.
   -->
 <resources>
-    <color name="azure_communication_ui_color_com_primary">#0086F0</color>
     <color name="azure_communication_ui_color_primary">#0086F0</color>
     <color name="azure_communication_ui_color_background">#141414</color>
     <color name="azure_communication_ui_color_bottom_drawer_background">#212121</color>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values/azure_communication_ui_colors.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values/azure_communication_ui_colors.xml
@@ -3,8 +3,7 @@
    Licensed under the MIT License.
   -->
 <resources>
-    <color name="azure_communication_ui_color_com_primary">#0078D4</color>
-    <color name="azure_communication_ui_color_primary">#3AA0F3</color>
+    <color name="azure_communication_ui_color_primary">#0078D4</color>
     <color name="azure_communication_ui_color_background">#FFFFFF</color>
     <color name="azure_communication_ui_color_bottom_drawer_background">#FFFFFF</color>
     <color name="azure_communication_ui_color_surface">#E1E1E1</color>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values/azure_communication_ui_themes.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values/azure_communication_ui_themes.xml
@@ -23,5 +23,7 @@
         <item name="azure_communication_ui_communication_tint_30">
             @color/fluentui_communication_tint_30
         </item>
+
+        <item name="titleTextColor">@color/azure_communication_ui_color_action_bar_text</item>
     </style>
 </resources>

--- a/azure-communication-ui/scripts/runUiTests.sh
+++ b/azure-communication-ui/scripts/runUiTests.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-./installEmulator.sh
+unset ANDROID_SERIAL
+DEVICE=($(adb devices | grep "device$" | sed -e "s|device||g"))
+if [ -z "$DEVICE" ]; then
+  ./installEmulator.sh
+fi
+
 cd ..
 #Replace ACS Token with expired token
 cat ./local.properties | sed -e '/^ACS_TOKEN=/d' > ./temp_file
@@ -11,5 +16,7 @@ mv -f ./temp_file ./local.properties
 ./gradlew clean cDAT -Pandroid.testInstrumentationRunnerArguments.teamsUrl="$2" -Pandroid.testInstrumentationRunnerArguments.groupId="$3" -Pandroid.testInstrumentationRunnerArguments.acsToken=$4
 
 # clean up
-adb emu kill
-$ANDROID_HOME/tools/bin/avdmanager delete avd -n xamarin_android_emulator
+if [ -z "$DEVICE" ]; then
+  adb emu kill
+  $ANDROID_HOME/tools/bin/avdmanager delete avd -n xamarin_android_emulator
+fi


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Changing title bar color now from theme instead of doing it programmatically. Fixes focus order-- focus to the speaker button after audio device selection list is closed.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
With talkback on, open and close audio device select menu, the focus should be on "Speaker" button. 

## Other Information
<!-- Add any other helpful information that may be needed here. -->
