### PR TITLE
[Bug] Fix feature flags crash when application context is not Initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.0-beta.3 (2022-04-04)
 
 ### Bug Fixes
-- Fixed crash when internal feature flag API was not initialized #175
+- Fixed crash when internal feature flag API was not initialized [#175](https://github.com/Azure/communication-ui-library-android/pull/175)
 
 ## 1.0.0-beta.2 (2022-04-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 1.0.0-beta.3 (2022-04-04)
 
 ### Bug Fixes
-- Fixed crash when internal feature flag API was not initialized
+- Fixed crash when internal feature flag API was not initialized #175
 
 ## 1.0.0-beta.2 (2022-04-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Release History
+
 ## 1.0.0-beta.3 (2022-04-04)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 1.0.0-beta.3 (2022-04-04)
 
 ### Bug Fixes
-- Fixed Crash when Internal Feature Flag API was not initialized
+- Fixed crash when internal feature flag API was not initialized
 
 ## 1.0.0-beta.2 (2022-04-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Release History
+## 1.0.0-beta.3 (2022-04-04)
+
+### Bug Fixes
+- Fixed Crash when Internal Feature Flag API was not initialized
 
 ## 1.0.0-beta.2 (2022-04-04)
 

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/main/java/com/azure/android/communication/ui/callingcompositedemoapp/features/AdditionalFeatures.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/main/java/com/azure/android/communication/ui/callingcompositedemoapp/features/AdditionalFeatures.kt
@@ -28,7 +28,10 @@ class AdditionalFeatures private constructor() {
             },
             end = {
                 MagnifierViewer.getMagnifierViewer(it).hide()
-            }
+            },
+            fallbackBoolean = false,
+            fallbackLabel = "FPS, Memory Diagnostics"
+
         )
 
         val secondaryThemeFeature = FeatureFlagEntry(
@@ -36,7 +39,9 @@ class AdditionalFeatures private constructor() {
             // Will use default false here
             labelId = R.string.secondary_theme,
             start = {},
-            end = {}
+            end = {},
+            fallbackBoolean = false,
+            fallbackLabel = "Secondary theme"
         )
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/service/calling/DiagnosticConfigUnitTests.kt
+++ b/azure-communication-ui/azure-communication-ui/src/test/java/com/azure/android/communication/ui/service/calling/DiagnosticConfigUnitTests.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 
 internal class DiagnosticConfigUnitTests {
     private val expectedPrefix = "aca110/"
-    private val expectedVersion = "${expectedPrefix}1.0.0-beta.2"
+    private val expectedVersion = "${expectedPrefix}1.0.0-beta.3"
 
     @Test
     fun test_Expected_Tag() {

--- a/azure-communication-ui/build.gradle
+++ b/azure-communication-ui/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         azure_core_version = '1.0.0-beta.9'
         appcompat_version = '1.3.1'
         androidx_core_version = '1.6.0'
-        ui_library_version_name = '1.0.0-beta.2'
+        ui_library_version_name = '1.0.0-beta.3'
         ui_library_version_code = getVersionCode()
         fluent_ui_version = '0.0.15'
         constraint_layout = '2.1.3'


### PR DESCRIPTION
Patch to make FeatureFlags safe if init is not called.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix crash when using .value when FeatureFlags wasn't initialized (code fallbacks/exception handling)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
