### PR TITLE
[Refactoring] Fix Accessibility issues for lobby overlay and calling gridlayout

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/CallingViewModel.kt
@@ -121,6 +121,8 @@ internal class CallingViewModel(
 
         lobbyOverlayViewModel.init(state.callState.callingStatus)
 
+        participantGridViewModel.init(state.callState.callingStatus)
+
         super.init(coroutineScope)
     }
 
@@ -152,6 +154,8 @@ internal class CallingViewModel(
         )
 
         lobbyOverlayViewModel.update(state.callState.callingStatus)
+
+        participantGridViewModel.updateIsLobbyOverlayDisplayed(state.callState.callingStatus)
 
         if (shouldUpdateRemoteParticipantsViewModels(state)) {
             participantGridViewModel.update(

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/lobby/LobbyOverlayView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/lobby/LobbyOverlayView.kt
@@ -5,9 +5,13 @@ package com.azure.android.communication.ui.presentation.fragment.calling.lobby
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.view.AccessibilityDelegateCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.azure.android.communication.ui.R
@@ -43,6 +47,17 @@ internal class LobbyOverlayView : LinearLayout {
                 visibility = if (it) VISIBLE else GONE
             }
         }
+
+        ViewCompat.setAccessibilityDelegate(
+            this,
+            object : AccessibilityDelegateCompat() {
+                override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfoCompat) {
+                    super.onInitializeAccessibilityNodeInfo(host, info)
+                    info.removeAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_CLICK)
+                    info.isClickable = false
+                }
+            }
+        )
     }
 
     private fun setupUi() {

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/participant/grid/ParticipantGridViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/calling/participant/grid/ParticipantGridViewModel.kt
@@ -5,6 +5,7 @@ package com.azure.android.communication.ui.presentation.fragment.calling.partici
 
 import com.azure.android.communication.ui.model.ParticipantInfoModel
 import com.azure.android.communication.ui.presentation.fragment.factories.ParticipantGridCellViewModelFactory
+import com.azure.android.communication.ui.redux.state.CallingStatus
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -21,6 +22,13 @@ internal class ParticipantGridViewModel(
     private var updateVideoStreamsCallback: ((List<Pair<String, String>>) -> Unit)? = null
     private var remoteParticipantStateModifiedTimeStamp: Number = 0
     private val maxRemoteParticipantSize = 6
+    private lateinit var isLobbyOverlayDisplayedFlow: MutableStateFlow<Boolean>
+
+    fun init(
+        callingStatus: CallingStatus,
+    ) {
+        isLobbyOverlayDisplayedFlow = MutableStateFlow(isLobbyOverlayDisplayed(callingStatus))
+    }
 
     fun clear() {
         remoteParticipantStateModifiedTimeStamp = 0
@@ -34,6 +42,12 @@ internal class ParticipantGridViewModel(
 
     fun setUpdateVideoStreamsCallback(callback: (List<Pair<String, String>>) -> Unit) {
         this.updateVideoStreamsCallback = callback
+    }
+
+    fun getIsLobbyOverlayDisplayedFlow(): StateFlow<Boolean> = isLobbyOverlayDisplayedFlow
+
+    fun updateIsLobbyOverlayDisplayed(callingStatus: CallingStatus) {
+        isLobbyOverlayDisplayedFlow.value = isLobbyOverlayDisplayed(callingStatus)
     }
 
     fun update(
@@ -175,4 +189,7 @@ internal class ParticipantGridViewModel(
         }
         updateVideoStreamsCallback?.invoke(usersVideoStream)
     }
+
+    private fun isLobbyOverlayDisplayed(callingStatus: CallingStatus) =
+        callingStatus == CallingStatus.IN_LOBBY
 }

--- a/azure-communication-ui/azure-communication-ui/src/main/res/layout/azure_communication_ui_call_header.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/layout/azure_communication_ui_call_header.xml
@@ -21,7 +21,6 @@
 
     <TextView
         android:id="@+id/azure_communication_ui_call_participant_number_text"
-        android:importantForAccessibility="no"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"


### PR DESCRIPTION
## Purpose

1. When lobby overlay is showing up, ignore unexpected announcement (e.g. double tap the overlay)
2. When lobby overlay is showing up, talkback should ignore gridlayout.
3. When talkback is on and join the call, talkback should not announce "double tap" for gridlayout since the floating header is always showing up.
4. Based on E+D team's suggestion, talkback can focus on number participant on the floating header.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Turn on Talkback or other screen reader
1. try to join a Teams' call -> when lobby overlay is showing up -> verify if talkback announce unexpected action "double tap" and announce unexpected info for gridlayout.
2. when join a call with talkback on, when focus on the gridlayout, verify if talkback announce unexpected "double tap" for it.
3. join a call with talkback on, swipe to focus on number of participant on the floating header to verify if talkback can read it.