### PR TITLE
[Bug] Language Dropdown Colour in Dark Mode

### DIFF
--- a/azure-communication-ui/azure-communication-ui-demo-app/src/main/res/layout/language_dropdown_item.xml
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/main/res/layout/language_dropdown_item.xml
@@ -8,6 +8,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:padding="16dp"
+    android:textColor="@color/black"
     android:text="TextView"
     android:textSize="16sp"
     android:textStyle="bold" />

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/main/res/values-night/colors.xml
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/main/res/values-night/colors.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="purple_200">#FFBB86FC</color>
+    <color name="purple_500">#FF6200EE</color>
+    <color name="purple_700">#FF3700B3</color>
+    <color name="teal_200">#FF03DAC5</color>
+    <color name="teal_700">#FF018786</color>
+    <color name="black">#FFFFFFFF</color>
+    <color name="white">#FF000000</color>
+    <color name="ACS_light">#FF3AA0F3</color>
+    <color name="ACS_dark">#FF0086F0</color>
+    <color name="Teams_light">#FF6264A7</color>
+    <color name="Teams_dark">#FF7A7FEA</color>
+</resources>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix language DropDown list in dark mode

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Change OS into DarkMode 
* Click on Language Selection 


## What to Check
Verify that the following are valid
* DarkMode is working fine
* LightMode is not broken

## Other Information
<!-- Add any other helpful information that may be needed here. -->
|Before-Dark|After-Dark|After-Light|
|---|---|---|
![MicrosoftTeams-image (8)](https://user-images.githubusercontent.com/93549644/162255260-4244536c-430b-4d8f-91fe-7c527828daae.png)|![MicrosoftTeams-image (9)](https://user-images.githubusercontent.com/93549644/162255323-8d2f4f68-5fe4-49c8-82a8-8337b9e1bb55.png)|![MicrosoftTeams-image (10)](https://user-images.githubusercontent.com/93549644/162255366-f0f54426-a8a8-48e8-8895-443fc1f6a9c4.png)|