### PR TITLE
[Bug] remote participant persona should be removed if handler is null

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/configuration/RemoteParticipantsConfiguration.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/configuration/RemoteParticipantsConfiguration.kt
@@ -18,7 +18,7 @@ internal interface RemoteParticipantsConfigurationHandler {
 }
 
 internal class RemoteParticipantsConfiguration {
-    private lateinit var handler: RemoteParticipantsConfigurationHandler
+    private var handler: RemoteParticipantsConfigurationHandler? = null
 
     fun setHandler(handler: RemoteParticipantsConfigurationHandler) {
         this.handler = handler
@@ -28,15 +28,18 @@ internal class RemoteParticipantsConfiguration {
         identifier: CommunicationIdentifier,
         personaData: PersonaData,
     ): SetPersonaDataResult {
-        return handler.onSetPersonaData(
-            RemoteParticipantPersonaData(
-                identifier,
-                personaData
+        if (handler != null) {
+            return handler!!.onSetPersonaData(
+                RemoteParticipantPersonaData(
+                    identifier,
+                    personaData
+                )
             )
-        )
+        }
+        return SetPersonaDataResult.PARTICIPANT_NOT_IN_CALL
     }
 
     fun removePersonaData(identifier: String) {
-        handler.onRemovePersonaData(identifier)
+        handler?.onRemovePersonaData(identifier)
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/handlers/RemoteParticipantHandler.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/handlers/RemoteParticipantHandler.kt
@@ -26,15 +26,15 @@ internal class RemoteParticipantHandler(
     }
 
     private fun onStateChanged(remoteParticipantsState: RemoteParticipantsState) {
-        if (configuration.callCompositeEventsHandler.getOnRemoteParticipantJoinedHandler() != null &&
-            remoteParticipantsState.modifiedTimestamp != lastRemoteParticipantsState?.modifiedTimestamp
-        ) {
-            if (lastRemoteParticipantsState != null) {
-                val joinedParticipants =
-                    remoteParticipantsState.participantMap.keys.filter { it !in lastRemoteParticipantsState!!.participantMap.keys }
-                sendRemoteParticipantJoinedEvent(joinedParticipants)
-            } else {
-                sendRemoteParticipantJoinedEvent(remoteParticipantsState.participantMap.keys.toList())
+        if (remoteParticipantsState.modifiedTimestamp != lastRemoteParticipantsState?.modifiedTimestamp) {
+            if (configuration.callCompositeEventsHandler.getOnRemoteParticipantJoinedHandler() != null) {
+                if (lastRemoteParticipantsState != null) {
+                    val joinedParticipants =
+                        remoteParticipantsState.participantMap.keys.filter { it !in lastRemoteParticipantsState!!.participantMap.keys }
+                    sendRemoteParticipantJoinedEvent(joinedParticipants)
+                } else {
+                    sendRemoteParticipantJoinedEvent(remoteParticipantsState.participantMap.keys.toList())
+                }
             }
 
             val leftParticipants =


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Bug 1: if call is not launched, setting persona should return participant not in call 
* Bug 2: After setting persona data, setting event handler to null, the participant persona should be removed from cache on leaving a call

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
