### PR TITLE
[Bug] Audio device selection talkback fix

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
@@ -4,11 +4,8 @@
 package com.azure.android.communication.ui.presentation.fragment.common.audiodevicelist
 
 import android.content.Context
-import android.content.DialogInterface
-import android.util.Log
 import android.widget.RelativeLayout
 import androidx.core.content.ContextCompat
-import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -187,10 +184,12 @@ internal class AudioDeviceListView(
     private fun updateSelectedAudioDevice(audioState: AudioState) {
         if (this::bottomCellAdapter.isInitialized) {
             bottomCellAdapter.enableBottomCellItem(getDeviceTypeName(audioState))
-            announceForAccessibility(context.getString(
-                R.string.azure_communication_ui_selected_audio_device_announcement,
-                getDeviceTypeName(audioState)
-            ))
+            announceForAccessibility(
+                context.getString(
+                    R.string.azure_communication_ui_selected_audio_device_announcement,
+                    getDeviceTypeName(audioState)
+                )
+            )
         }
     }
 

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
@@ -58,22 +58,6 @@ internal class AudioDeviceListView(
                 deviceTable.adapter = bottomCellAdapter
             }
         }
-
-//        viewLifecycleOwner.lifecycleScope.launch {
-//            viewModel.getIsLobbyOverlayDisplayedFlow().collect {
-//                if (it) {
-//                    ViewCompat.setImportantForAccessibility(
-//                        deviceTable,
-//                        ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
-//                    )
-//                } else {
-//                    ViewCompat.setImportantForAccessibility(
-//                        deviceTable,
-//                        ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES
-//                    )
-//                }
-//            }
-//        }
     }
 
     fun stop() {

--- a/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/main/java/com/azure/android/communication/ui/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
@@ -4,8 +4,11 @@
 package com.azure.android.communication.ui.presentation.fragment.common.audiodevicelist
 
 import android.content.Context
+import android.content.DialogInterface
+import android.util.Log
 import android.widget.RelativeLayout
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -58,6 +61,22 @@ internal class AudioDeviceListView(
                 deviceTable.adapter = bottomCellAdapter
             }
         }
+
+//        viewLifecycleOwner.lifecycleScope.launch {
+//            viewModel.getIsLobbyOverlayDisplayedFlow().collect {
+//                if (it) {
+//                    ViewCompat.setImportantForAccessibility(
+//                        deviceTable,
+//                        ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+//                    )
+//                } else {
+//                    ViewCompat.setImportantForAccessibility(
+//                        deviceTable,
+//                        ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES
+//                    )
+//                }
+//            }
+//        }
     }
 
     fun stop() {
@@ -168,6 +187,10 @@ internal class AudioDeviceListView(
     private fun updateSelectedAudioDevice(audioState: AudioState) {
         if (this::bottomCellAdapter.isInitialized) {
             bottomCellAdapter.enableBottomCellItem(getDeviceTypeName(audioState))
+            announceForAccessibility(context.getString(
+                R.string.azure_communication_ui_selected_audio_device_announcement,
+                getDeviceTypeName(audioState)
+            ))
         }
     }
 
@@ -175,10 +198,10 @@ internal class AudioDeviceListView(
         return when (audioState.device) {
             AudioDeviceSelectionStatus.RECEIVER_REQUESTED, AudioDeviceSelectionStatus.RECEIVER_SELECTED ->
                 context.getString(R.string.azure_communication_ui_audio_device_drawer_android)
-
             AudioDeviceSelectionStatus.SPEAKER_REQUESTED, AudioDeviceSelectionStatus.SPEAKER_SELECTED ->
                 context.getString(R.string.azure_communication_ui_audio_device_drawer_speaker)
-            AudioDeviceSelectionStatus.BLUETOOTH_SCO_SELECTED, AudioDeviceSelectionStatus.BLUETOOTH_SCO_REQUESTED -> audioState.bluetoothState.deviceName
+            AudioDeviceSelectionStatus.BLUETOOTH_SCO_SELECTED, AudioDeviceSelectionStatus.BLUETOOTH_SCO_REQUESTED ->
+                audioState.bluetoothState.deviceName
         }
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-de-rDE/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-de-rDE/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Zur Frontkamera wechseln</string>
     <string name="azure_communication_ui_switch_camera_button_back">Zur Rückkamera wechseln</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Audiogerät auswählen %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Teilnehmen am Anruf…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Video aus</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Schließen</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Warnung</string>
     <string name="azure_communication_ui_call_state_error_call_end">Sie wurden aufgrund eines Fehlers aus dem Anruf entfernt.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Teilnahme am Anruf aufgrund eines Fehlers nicht möglich.</string>
     <string name="azure_communication_ui_call_state_evicted">Sie wurden aus dem Anruf entfernt.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-de/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-de/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Zur Frontkamera wechseln</string>
     <string name="azure_communication_ui_switch_camera_button_back">Zur Rückkamera wechseln</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Audiogerät auswählen %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Teilnehmen am Anruf…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Video aus</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Schließen</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Warnung</string>
     <string name="azure_communication_ui_call_state_error_call_end">Sie wurden aufgrund eines Fehlers aus dem Anruf entfernt.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Teilnahme am Anruf aufgrund eines Fehlers nicht möglich.</string>
     <string name="azure_communication_ui_call_state_evicted">Sie wurden aus dem Anruf entfernt.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-en-rGB/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-en-rGB/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Switch to Front Camera</string>
     <string name="azure_communication_ui_switch_camera_button_back">Switch to Back Camera</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Select Audio Device %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Joining call…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Video off</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-en-rUS/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-en-rUS/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Switch to Front Camera</string>
     <string name="azure_communication_ui_switch_camera_button_back">Switch to Back Camera</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Select Audio Device %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Joining call…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Video off</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-es-rES/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-es-rES/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Cambiar a cámara frontal</string>
     <string name="azure_communication_ui_switch_camera_button_back">Cambiar a cámara trasera</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Seleccionar dispositivo de audio %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Uniéndose a la llamada…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Vídeo desactivado</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Descartar</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Alerta</string>
     <string name="azure_communication_ui_call_state_error_call_end">Se le ha quitado de la llamada debido a un error.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">No se puede unir a la llamada debido a un error.</string>
     <string name="azure_communication_ui_call_state_evicted">Le han eliminado de la llamada.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-es/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-es/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Cambiar a cámara frontal</string>
     <string name="azure_communication_ui_switch_camera_button_back">Cambiar a cámara trasera</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Seleccionar dispositivo de audio %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Uniéndose a la llamada…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Vídeo desactivado</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Descartar</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Alerta</string>
     <string name="azure_communication_ui_call_state_error_call_end">Se le ha quitado de la llamada debido a un error.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">No se puede unir a la llamada debido a un error.</string>
     <string name="azure_communication_ui_call_state_evicted">Le han eliminado de la llamada.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-fr-rFR/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-fr-rFR/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Basculer vers la caméra avant</string>
     <string name="azure_communication_ui_switch_camera_button_back">Basculer vers la caméra arrière</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Sélectionner un %1$s de périphérique audio</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Connexion à l\'appel…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Vidéo désactivée</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Ignorer</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Alerte</string>
     <string name="azure_communication_ui_call_state_error_call_end">Vous avez été supprimé de l’appel en raison d’une erreur.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Impossible de rejoindre l’appel en raison d’une erreur.</string>
     <string name="azure_communication_ui_call_state_evicted">Vous avez été retiré de l’appel.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-fr/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-fr/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Basculer vers la caméra avant</string>
     <string name="azure_communication_ui_switch_camera_button_back">Basculer vers la caméra arrière</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Sélectionner un %1$s de périphérique audio</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Connexion à l\'appel…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Vidéo désactivée</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Ignorer</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Alerte</string>
     <string name="azure_communication_ui_call_state_error_call_end">Vous avez été supprimé de l’appel en raison d’une erreur.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Impossible de rejoindre l’appel en raison d’une erreur.</string>
     <string name="azure_communication_ui_call_state_evicted">Vous avez été retiré de l’appel.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-it-rIT/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-it-rIT/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Passa alla fotocamera anteriore</string>
     <string name="azure_communication_ui_switch_camera_button_back">Passa alla videocamera posteriore</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Seleziona dispositivo audio %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Partecipazione alla chiamata…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Video disattivato</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Ignora</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Avviso</string>
     <string name="azure_communication_ui_call_state_error_call_end">Sei stato rimosso dalla chiamata a causa di un errore.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Impossibile partecipare alla chiamata a causa di un errore.</string>
     <string name="azure_communication_ui_call_state_evicted">Sei stato rimosso dalla chiamata.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-it/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-it/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Passa alla fotocamera anteriore</string>
     <string name="azure_communication_ui_switch_camera_button_back">Passa alla videocamera posteriore</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Seleziona dispositivo audio %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Partecipazione alla chiamata…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Video disattivato</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Ignora</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Avviso</string>
     <string name="azure_communication_ui_call_state_error_call_end">Sei stato rimosso dalla chiamata a causa di un errore.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Impossibile partecipare alla chiamata a causa di un errore.</string>
     <string name="azure_communication_ui_call_state_evicted">Sei stato rimosso dalla chiamata.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-ja-rJP/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-ja-rJP/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">フロント カメラに切り替える</string>
     <string name="azure_communication_ui_switch_camera_button_back">バック カメラに切り替える</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">オーディオ デバイス %1$s の選択</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">参加中…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">ビデオ オフ</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">却下</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">アラート</string>
     <string name="azure_communication_ui_call_state_error_call_end">エラーが発生したため、通話から削除されました。</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">エラーが発生したため、通話に参加できません。</string>
     <string name="azure_communication_ui_call_state_evicted">通話から削除されました。</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-ja/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-ja/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">フロント カメラに切り替える</string>
     <string name="azure_communication_ui_switch_camera_button_back">バック カメラに切り替える</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">オーディオ デバイス %1$s の選択</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">参加中…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">ビデオ オフ</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">却下</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">アラート</string>
     <string name="azure_communication_ui_call_state_error_call_end">エラーが発生したため、通話から削除されました。</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">エラーが発生したため、通話に参加できません。</string>
     <string name="azure_communication_ui_call_state_evicted">通話から削除されました。</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-ko-rKR/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-ko-rKR/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">전면 카메라로 전환</string>
     <string name="azure_communication_ui_switch_camera_button_back">후면 카메라로 전환</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">오디오 장치 %1$s 선택</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">통화에 참가하는 중…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">비디오 끄기</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">해제</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">알림</string>
     <string name="azure_communication_ui_call_state_error_call_end">오류로 인해 통화에서 제외되었습니다.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">오류로 인해 통화에 참가할 수 없습니다.</string>
     <string name="azure_communication_ui_call_state_evicted">통화에서 제거되었습니다.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-ko/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-ko/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">전면 카메라로 전환</string>
     <string name="azure_communication_ui_switch_camera_button_back">후면 카메라로 전환</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">오디오 장치 %1$s 선택</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">통화에 참가하는 중…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">비디오 끄기</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">해제</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">알림</string>
     <string name="azure_communication_ui_call_state_error_call_end">오류로 인해 통화에서 제외되었습니다.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">오류로 인해 통화에 참가할 수 없습니다.</string>
     <string name="azure_communication_ui_call_state_evicted">통화에서 제거되었습니다.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-nl-rNL/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-nl-rNL/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Overschakelen naar camera aan voorzijde</string>
     <string name="azure_communication_ui_switch_camera_button_back">Overschakelen naar de camera aan achterzijde</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Audioapparaat %1$s selecteren</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Deelnemen aan gesprek…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Video uit</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Sluiten</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Waarschuwing</string>
     <string name="azure_communication_ui_call_state_error_call_end">U bent uit de oproep verwijderd vanwege een fout.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Kan niet deelnemen aan de oproep vanwege een fout.</string>
     <string name="azure_communication_ui_call_state_evicted">U bent verwijderd uit het gesprek.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-nl/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-nl/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Overschakelen naar camera aan voorzijde</string>
     <string name="azure_communication_ui_switch_camera_button_back">Overschakelen naar de camera aan achterzijde</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Audioapparaat %1$s selecteren</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Deelnemen aan gesprek…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Video uit</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Sluiten</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Waarschuwing</string>
     <string name="azure_communication_ui_call_state_error_call_end">U bent uit de oproep verwijderd vanwege een fout.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Kan niet deelnemen aan de oproep vanwege een fout.</string>
     <string name="azure_communication_ui_call_state_evicted">U bent verwijderd uit het gesprek.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-pt-rBR/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-pt-rBR/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Alternar Para a Câmera Frontal</string>
     <string name="azure_communication_ui_switch_camera_button_back">Alternar Para a Câmera Traseira</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Selecionar o Dispositivo de Áudio %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Ingressando na chamada…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Vídeo desativado</string>
@@ -75,7 +76,7 @@ dando consentimento para que esta reunião seja transcrita.
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Ignorar</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Alerta</string>
     <string name="azure_communication_ui_call_state_error_call_end">Você foi removido da chamada devido a um erro.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Não é possível ingressar na chamada devido a um erro.</string>
     <string name="azure_communication_ui_call_state_evicted">Você foi removido da chamada.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-pt/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-pt/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Alternar Para a Câmera Frontal</string>
     <string name="azure_communication_ui_switch_camera_button_back">Alternar Para a Câmera Traseira</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Selecionar o Dispositivo de Áudio %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Ingressando na chamada…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Vídeo desativado</string>
@@ -75,7 +76,7 @@ dando consentimento para que esta reunião seja transcrita.
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Ignorar</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Alerta</string>
     <string name="azure_communication_ui_call_state_error_call_end">Você foi removido da chamada devido a um erro.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Não é possível ingressar na chamada devido a um erro.</string>
     <string name="azure_communication_ui_call_state_evicted">Você foi removido da chamada.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-ru-rRU/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-ru-rRU/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Переключиться на переднюю камеру</string>
     <string name="azure_communication_ui_switch_camera_button_back">Переключиться на заднюю камеру</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Выбрать звуковое устройство %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Подключение к звонку…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Видео отключено</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Закрыть</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Оповещение</string>
     <string name="azure_communication_ui_call_state_error_call_end">Вы были удалены из звонка из-за ошибки.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Не удалось присоединиться к звонку из-за ошибки.</string>
     <string name="azure_communication_ui_call_state_evicted">Вас удалили из звонка.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-ru/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-ru/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Переключиться на переднюю камеру</string>
     <string name="azure_communication_ui_switch_camera_button_back">Переключиться на заднюю камеру</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Выбрать звуковое устройство %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Подключение к звонку…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Видео отключено</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Закрыть</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Оповещение</string>
     <string name="azure_communication_ui_call_state_error_call_end">Вы были удалены из звонка из-за ошибки.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Не удалось присоединиться к звонку из-за ошибки.</string>
     <string name="azure_communication_ui_call_state_evicted">Вас удалили из звонка.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-tr-rTR/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-tr-rTR/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Ön Kameraya Geç</string>
     <string name="azure_communication_ui_switch_camera_button_back">Arka Kameraya Geç</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">%1$s Ses Cihazını Seç</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Aramaya katılıyorsunuz…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Görüntü kapalı</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Yoksay</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Uyarı</string>
     <string name="azure_communication_ui_call_state_error_call_end">Bir hata nedeniyle aramadan çıkarıldınız.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Bir hata nedeniyle aramaya katılınamıyor.</string>
     <string name="azure_communication_ui_call_state_evicted">Aramadan çıkarıldınız.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-tr/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-tr/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Ön Kameraya Geç</string>
     <string name="azure_communication_ui_switch_camera_button_back">Arka Kameraya Geç</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">%1$s Ses Cihazını Seç</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Aramaya katılıyorsunuz…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Görüntü kapalı</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">Yoksay</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">Uyarı</string>
     <string name="azure_communication_ui_call_state_error_call_end">Bir hata nedeniyle aramadan çıkarıldınız.</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">Bir hata nedeniyle aramaya katılınamıyor.</string>
     <string name="azure_communication_ui_call_state_evicted">Aramadan çıkarıldınız.</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-zh-rCN/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-zh-rCN/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">切换到前置摄像头</string>
     <string name="azure_communication_ui_switch_camera_button_back">切换到后置摄像头</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">选择音频设备 %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">正在加入通话…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">视频关闭</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">关闭</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">警报</string>
     <string name="azure_communication_ui_call_state_error_call_end">由于出现错误，你已从通话中删除。</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">由于出现错误，无法加入呼叫。</string>
     <string name="azure_communication_ui_call_state_evicted">已将你从通话中移除。</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-zh-rTW/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-zh-rTW/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">切換到前置相機</string>
     <string name="azure_communication_ui_switch_camera_button_back">切換到後置相機</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">選取音訊裝置 %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">正在加入通話…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">視訊關閉</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">關閉</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">提醒</string>
     <string name="azure_communication_ui_call_state_error_call_end">因為發生錯誤，您已從通話中移除。</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">因為發生錯誤，所以無法加入通話。</string>
     <string name="azure_communication_ui_call_state_evicted">已從通話中移除您。</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values-zh/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values-zh/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">切换到前置摄像头</string>
     <string name="azure_communication_ui_switch_camera_button_back">切换到后置摄像头</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">选择音频设备 %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">正在加入通话…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">视频关闭</string>
@@ -75,7 +76,7 @@
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_snack_bar_button_dismiss">关闭</string>
-    <string name="azure_communication_ui_alert_title">Alert</string>
+    <string name="azure_communication_ui_alert_title">警报</string>
     <string name="azure_communication_ui_call_state_error_call_end">由于出现错误，你已从通话中删除。</string>
     <string name="azure_communication_ui_snack_bar_text_error_call_join">由于出现错误，无法加入呼叫。</string>
     <string name="azure_communication_ui_call_state_evicted">已将你从通话中移除。</string>

--- a/azure-communication-ui/azure-communication-ui/src/main/res/values/azure_communication_ui_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/main/res/values/azure_communication_ui_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_switch_camera_button_front">Switch to Front Camera</string>
     <string name="azure_communication_ui_switch_camera_button_back">Switch to Back Camera</string>
     <string name="azure_communication_ui_setup_audio_device_select_content_description">Select Audio Device %1$s</string>
+    <string name="azure_communication_ui_selected_audio_device_announcement">%1$s audio device, selected</string>
     <!--    Setup View-->
     <string name="azure_communication_ui_setup_view_button_connecting_call">Joining call…</string>
     <string name="azure_communication_ui_setup_view_button_video_off">Video off</string>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Accessibility bug on audio device selection no announcement fix

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Turn on the Talkback
* Navigate to call setup page
* Navigate to open Audio device select menu
* swipe to choose either of them, then double tap to select it

## What to Check
Verify that the following are valid
* Screen reader should announce something like "Android audio device, selected" or "Speaker audio device, selected"

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Bug ticket: https://skype.visualstudio.com/SPOOL/_sprints/taskboard/ACS%20Mobile%20UI%20-%20Android/SPOOL/CY2022-Q2/Sprint%2062%20(Ends%20May%2015)?workitem=2821795