### PR TITLE
[Bug] Banner Talkback order change

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/banner/BannerView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/banner/BannerView.kt
@@ -68,7 +68,7 @@ internal class BannerView : ConstraintLayout {
             bannerText.text = getBannerInfo(bannerInfoType)
             bannerText.setOnClickListener(getBannerClickDestination(bannerInfoType))
 
-            val textToAnnounce = "${context.getString(R.string.azure_communication_ui_calling_alert_title)}: ${bannerText.text} ${context.getString(R.string.azure_communication_ui_calling_view_link)}"
+            val textToAnnounce = "${context.getString(R.string.azure_communication_ui_calling_alert_title)}: ${context.getString(R.string.azure_communication_ui_calling_view_button_close_button_full_accessibility_label)}, ${bannerText.text} ${context.getString(R.string.azure_communication_ui_calling_view_link)}"
             announceForAccessibility(textToAnnounce)
         }
         // Below code helps to display banner message on screen rotate. When recording and transcription being saved is displayed
@@ -78,7 +78,7 @@ internal class BannerView : ConstraintLayout {
             bannerText.text = getBannerInfo(viewModel.getDisplayedBannerType())
             bannerText.setOnClickListener(getBannerClickDestination(bannerInfoType))
 
-            val textToAnnounce = "${context.getString(R.string.azure_communication_ui_calling_alert_title)}: ${bannerText.text} ${context.getString(R.string.azure_communication_ui_calling_view_link)}"
+            val textToAnnounce = "${context.getString(R.string.azure_communication_ui_calling_alert_title)}: ${context.getString(R.string.azure_communication_ui_calling_view_button_close_button_full_accessibility_label)}, ${bannerText.text} ${context.getString(R.string.azure_communication_ui_calling_view_link)}"
             announceForAccessibility(textToAnnounce)
         }
     }

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-de-rDE/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-de-rDE/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Stummschaltung aufgehoben</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Auflegen</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Schaltfläche „Schließen“</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Auf Video umschalten</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Auf Audio umschalten</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Geräteoptionen</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-de/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-de/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Stummschaltung aufgehoben</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Auflegen</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Schaltfläche „Schließen“</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Auf Video umschalten</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Auf Audio umschalten</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Geräteoptionen</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-en-rGB/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-en-rGB/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Unmuted</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Hang Up</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Close Button</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Toggle Video</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Toggle Audio</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Device Options</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-es-rES/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-es-rES/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Audio reactivado</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Colgar</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Botón Cerrar</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Activar/desactivar vídeo</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Activar/desactivar audio</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Opciones de dispositivo</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-es/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-es/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Audio reactivado</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Colgar</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Botón Cerrar</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Activar/desactivar vídeo</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Activar/desactivar audio</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Opciones de dispositivo</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-fr-rFR/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-fr-rFR/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Son réactivé</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Raccrocher</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Bouton Fermer</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Activer/désactiver la vidéo</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Activer/désactiver l’audio</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Options du périphérique</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-fr/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-fr/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Son réactivé</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Raccrocher</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Bouton Fermer</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Activer/désactiver la vidéo</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Activer/désactiver l’audio</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Options du périphérique</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-it-rIT/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-it-rIT/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Microfono riattivato</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Disconnetti</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Pulsante Chiudi</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Attiva/disattiva video</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Attiva/Disattiva audio</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Opzioni dispositivo</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-it/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-it/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Microfono riattivato</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Disconnetti</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Pulsante Chiudi</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Attiva/disattiva video</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Attiva/Disattiva audio</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Opzioni dispositivo</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-ja-rJP/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-ja-rJP/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">ミュート解除</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">切断</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">[閉じる] ボタン</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">ビデオの切り替え</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">オーディオの切り替え</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">デバイス オプション</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-ja/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-ja/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">ミュート解除</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">切断</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">[閉じる] ボタン</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">ビデオの切り替え</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">オーディオの切り替え</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">デバイス オプション</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-ko-rKR/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-ko-rKR/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">음소거 해제됨</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">끊기</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">닫기 단추</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">비디오 설정/해제</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">오디오 설정/해제</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">디바이스 옵션</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-ko/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-ko/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">음소거 해제됨</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">끊기</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">닫기 단추</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">비디오 설정/해제</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">오디오 설정/해제</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">디바이스 옵션</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-nl-rNL/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-nl-rNL/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Dempen opgeheven</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Ophangen</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Knop Sluiten</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Video in-/uitschakelen</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Audio in-/uitschakelen</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Apparaatopties</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-nl/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-nl/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Dempen opgeheven</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Ophangen</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Knop Sluiten</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Video in-/uitschakelen</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Audio in-/uitschakelen</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Apparaatopties</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-pt-rBR/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-pt-rBR/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Mudo Desativado</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Desligar</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Botão Fechar</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Ativar/Desativar Vídeo</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Ativar/Desativar Áudio</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Opções do Dispositivo</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-pt/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-pt/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Mudo Desativado</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Desligar</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Botão Fechar</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Ativar/Desativar Vídeo</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Ativar/Desativar Áudio</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Opções do Dispositivo</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-ru-rRU/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-ru-rRU/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Звук включен</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Повесить трубку</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Кнопка "Закрыть"</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Включить или отключить видео</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Включить или отключить звук</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Параметры устройства</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-ru/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-ru/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Звук включен</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Повесить трубку</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Кнопка "Закрыть"</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Включить или отключить видео</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Включить или отключить звук</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Параметры устройства</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-tr-rTR/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-tr-rTR/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Sesi açıldı</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Kapat</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Kapat Düğmesi</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Görüntüyü Aç/Kapat</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Sesi Aç/Kapat</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Cihaz Seçenekleri</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-tr/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-tr/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Sesi açıldı</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Kapat</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Kapat Düğmesi</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Görüntüyü Aç/Kapat</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Sesi Aç/Kapat</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Cihaz Seçenekleri</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-zh-rCN/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-zh-rCN/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">已取消静音</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">挂断</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">“关闭”按钮</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">切换视频</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">切换音频</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">设备选项</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-zh-rTW/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-zh-rTW/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">已取消靜音</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">掛斷</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">[關閉] 按鈕</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">切換視訊</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">切換音訊</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">裝置選項</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-zh/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-zh/azure_communication_ui_calling_strings.xml
@@ -48,6 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">已取消静音</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">挂断</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">“关闭”按钮</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">切换视频</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">切换音频</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">设备选项</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values/azure_communication_ui_calling_strings.xml
@@ -49,6 +49,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Unmuted</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Hang Up</string>
     <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Close</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_full_accessibility_label">Close Button</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Toggle Video</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Toggle Audio</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Device Options</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values/azure_communication_ui_calling_strings.xml
@@ -48,7 +48,7 @@
     <string name="azure_communication_ui_calling_view_participant_list_muted_accessibility_label">Muted</string>
     <string name="azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label">Unmuted</string>
     <string name="azure_communication_ui_calling_view_button_hang_up_accessibility_label">Hang Up</string>
-    <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Close Button</string>
+    <string name="azure_communication_ui_calling_view_button_close_button_accessibility_label">Close</string>
     <string name="azure_communication_ui_calling_view_button_toggle_video_accessibility_label">Toggle Video</string>
     <string name="azure_communication_ui_calling_view_button_toggle_audio_accessibility_label">Toggle Audio</string>
     <string name="azure_communication_ui_calling_view_button_device_options_accessibility_label">Device Options</string>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Fixes talkback order for banner view. E+D team requested that the banner should be announced as follows: "Alert: close button, recording and transcription has started, by joining you are giving consent for this me.... Privacy Policy Link"



## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid

Banner is announced in this format: : "Alert: close button, recording and transcription has started, by joining you are giving .... Privacy Policy Link"

## Other Information
<!-- Add any other helpful information that may be needed here. -->
