### PR TITLE
[Task] Disable switching cameras while hold

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantViewModel.kt
@@ -63,7 +63,8 @@ internal class LocalParticipantViewModel(
         displayPipSwitchCameraButtonFlow.value =
             displayVideo && viewMode == LocalParticipantViewMode.PIP
         enableCameraSwitchFlow.value =
-            cameraDeviceSelectionStatus != CameraDeviceSelectionStatus.SWITCHING
+            cameraDeviceSelectionStatus != CameraDeviceSelectionStatus.SWITCHING &&
+            callingState != CallingStatus.LOCAL_HOLD
         cameraDeviceSelectionFlow.value = cameraDeviceSelectionStatus
         numberOfRemoteParticipantsFlow.value = numberOfRemoteParticipants
     }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* While a call is on hold, it should not be allowed to switch between front and back cameras, and this PR fixes this by hooking up the `enableCameraSwitchFlow` to `callingState`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open a new call
* Start another call on another calling software and then switch back to ACS Call
* You should arrive in Local Call Hold state, where the Hold Overlay is preventing access to the Local Participant View area
* Turn on TalkBack accessibility (press and hold both volume buttons)
* Swipe to navigate to the Switch Camera button


## What to Check
Verify that the following are valid
* While the call is on hold, the switch camera button will be disabled
* End the call from the remote side and the local hold will be removed and the switch camera should get enabled again

