### PR TITLE
[Bug] Correct banner close button talkback

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/banner/BannerView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/banner/BannerView.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.net.Uri
 import android.util.AttributeSet
 import android.view.View
+import android.view.View.OnClickListener
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -70,6 +71,8 @@ internal class BannerView : ConstraintLayout {
 
             val textToAnnounce = "${context.getString(R.string.azure_communication_ui_calling_alert_title)}: ${context.getString(R.string.azure_communication_ui_calling_view_button_close_button_full_accessibility_label)}, ${bannerText.text} ${context.getString(R.string.azure_communication_ui_calling_view_link)}"
             announceForAccessibility(textToAnnounce)
+
+            bannerCloseButton.contentDescription = "${getBannerTitle(bannerText.text)}: ${context.getString(R.string.azure_communication_ui_calling_view_button_close_button_accessibility_label)}"
         }
         // Below code helps to display banner message on screen rotate. When recording and transcription being saved is displayed
         // and screen is rotated, blank banner is displayed.
@@ -80,6 +83,8 @@ internal class BannerView : ConstraintLayout {
 
             val textToAnnounce = "${context.getString(R.string.azure_communication_ui_calling_alert_title)}: ${context.getString(R.string.azure_communication_ui_calling_view_button_close_button_full_accessibility_label)}, ${bannerText.text} ${context.getString(R.string.azure_communication_ui_calling_view_link)}"
             announceForAccessibility(textToAnnounce)
+
+            bannerCloseButton.contentDescription = "${getBannerTitle(bannerText.text)}: ${context.getString(R.string.azure_communication_ui_calling_view_button_close_button_accessibility_label)}"
         }
     }
 
@@ -138,6 +143,10 @@ internal class BannerView : ConstraintLayout {
                 context.getText(R.string.azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped)
             else -> ""
         }
+    }
+
+    private fun getBannerTitle(bannerText: CharSequence): CharSequence {
+        return bannerText.substring(0, bannerText.indexOf("."))
     }
 
     override fun onFinishInflate() {

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_call_banner.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_call_banner.xml
@@ -41,6 +41,5 @@
         android:src="@drawable/azure_communication_ui_calling_ic_fluent_dismiss_12_regular"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        android:contentDescription="@string/azure_communication_ui_calling_view_button_close_button_accessibility_label"
         />
 </com.azure.android.communication.ui.calling.presentation.fragment.calling.banner.BannerView>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Close button talkback should now announce the banner title and then the button description. For example: "Close button" -> "Recording has started. Close button"

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
Banner title is announced before "close button" when focused on banner close button

## Other Information
<!-- Add any other helpful information that may be needed here. -->
