### PR TITLE
[Bug] AudioFocus memory leak

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/CallCompositeActivity.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/CallCompositeActivity.kt
@@ -125,7 +125,6 @@ internal class CallCompositeActivity : AppCompatActivity() {
         if (!isChangingConfigurations) {
             lifecycleScope.launch {
                 lifecycleManager.pause()
-                audioFocusManager.stop()
             }
         }
     }
@@ -135,6 +134,7 @@ internal class CallCompositeActivity : AppCompatActivity() {
         // (e.g. due to revoked permission).
         // If no configs are detected we can just exit without cleanup.
         if (CallCompositeConfiguration.hasConfig(instanceId)) {
+            audioFocusManager.stop()
             audioSessionManager.onDestroy(this)
             if (isFinishing) {
                 store.dispatch(CallingAction.CallEndRequested())

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/CallCompositeActivity.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/CallCompositeActivity.kt
@@ -123,7 +123,10 @@ internal class CallCompositeActivity : AppCompatActivity() {
     override fun onStop() {
         super.onStop()
         if (!isChangingConfigurations) {
-            lifecycleScope.launch { lifecycleManager.pause() }
+            lifecycleScope.launch {
+                lifecycleManager.pause()
+                audioFocusManager.stop()
+            }
         }
     }
 

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/AudioFocusManager.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/AudioFocusManager.kt
@@ -31,18 +31,18 @@ internal abstract class AudioFocusHandler : AudioManager.OnAudioFocusChangeListe
 // Newer API Version of AudioFocusHandler
 @RequiresApi(Build.VERSION_CODES.O)
 internal class AudioFocusHandler26(val context: Context) : AudioFocusHandler() {
-    private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private fun audioManager() = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
     private val audioFocusRequest26 = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
         .setOnAudioFocusChangeListener(this).build()
 
     override fun getAudioFocus() =
-        audioManager.requestAudioFocus(audioFocusRequest26) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        audioManager().requestAudioFocus(audioFocusRequest26) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
 
-    override fun getMode() = audioManager.mode
+    override fun getMode() = audioManager().mode
 
     override fun releaseAudioFocus() =
-        audioManager.abandonAudioFocusRequest(audioFocusRequest26) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        audioManager().abandonAudioFocusRequest(audioFocusRequest26) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
 }
 
 // Legacy AudioFocus API
@@ -122,7 +122,9 @@ internal class AudioFocusManager(
             }
         }
     }
+
     fun stop() {
         audioFocusHandler?.onFocusChange = null
+        audioFocusHandler?.releaseAudioFocus()
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/AudioFocusManager.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/AudioFocusManager.kt
@@ -76,7 +76,9 @@ internal class AudioFocusManager(
         } else {
             AudioFocusHandlerLegacy(applicationContext)
         }
+    }
 
+    suspend fun start() {
         audioFocusHandler?.onFocusChange = {
             // Todo: AudioFocus can be resumed as well (e.g. transient is temporary, we will get back.
             // I.e. like how spotify can continue playing after a call is done.
@@ -87,9 +89,6 @@ internal class AudioFocusManager(
                 store.dispatch(AudioSessionAction.AudioFocusInterrupted())
             }
         }
-    }
-
-    suspend fun start() {
         store.getStateFlow().collect {
             if (previousAudioFocusStatus != it.audioSessionState.audioFocusStatus) {
                 previousAudioFocusStatus = it.audioSessionState.audioFocusStatus
@@ -122,5 +121,8 @@ internal class AudioFocusManager(
                 }
             }
         }
+    }
+    fun stop() {
+        audioFocusHandler?.onFocusChange = null
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/AudioFocusManager.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/AudioFocusManager.kt
@@ -48,17 +48,17 @@ internal class AudioFocusHandler26(val context: Context) : AudioFocusHandler() {
 // Legacy AudioFocus API
 @Suppress("DEPRECATION")
 internal class AudioFocusHandlerLegacy(val context: Context) : AudioFocusHandler() {
-    private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private fun audioManager() = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
-    override fun getAudioFocus() = audioManager.requestAudioFocus(
+    override fun getAudioFocus() = audioManager().requestAudioFocus(
         this,
         AudioManager.STREAM_VOICE_CALL, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
     ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
 
-    override fun getMode() = audioManager.mode
+    override fun getMode() = audioManager().mode
 
     override fun releaseAudioFocus(): Boolean =
-        audioManager.abandonAudioFocus(this) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        audioManager().abandonAudioFocus(this) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
 }
 
 internal class AudioFocusManager(


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes leak at onFocusChange listener function var

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open the app from Android Studio in memory profiler mode and start a call
* End the call
* Repeat several times (3-5)
* End the Activity (use hardware back button to get out of the app)
* Test mic-hold-release as per call hold feature tests (should auto-hold when another call starts, shouldn't allow resuming call when mic is not available, should auto-resume call when possible)


## What to Check
Verify that the following are valid
* Without this PR the listener function is retained and the AudioFocusManager is being held in memory
