### PR TITLE
[Bug] fix call hold not triggering on some devices

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/AudioFocusManager.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/AudioFocusManager.kt
@@ -31,34 +31,34 @@ internal abstract class AudioFocusHandler : AudioManager.OnAudioFocusChangeListe
 // Newer API Version of AudioFocusHandler
 @RequiresApi(Build.VERSION_CODES.O)
 internal class AudioFocusHandler26(val context: Context) : AudioFocusHandler() {
-    private fun audioManager() = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
     private val audioFocusRequest26 = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
         .setOnAudioFocusChangeListener(this).build()
 
     override fun getAudioFocus() =
-        audioManager().requestAudioFocus(audioFocusRequest26) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        audioManager.requestAudioFocus(audioFocusRequest26) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
 
-    override fun getMode() = audioManager().mode
+    override fun getMode() = audioManager.mode
 
     override fun releaseAudioFocus() =
-        audioManager().abandonAudioFocusRequest(audioFocusRequest26) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        audioManager.abandonAudioFocusRequest(audioFocusRequest26) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
 }
 
 // Legacy AudioFocus API
 @Suppress("DEPRECATION")
 internal class AudioFocusHandlerLegacy(val context: Context) : AudioFocusHandler() {
-    private fun audioManager() = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
-    override fun getAudioFocus() = audioManager().requestAudioFocus(
+    override fun getAudioFocus() = audioManager.requestAudioFocus(
         this,
         AudioManager.STREAM_VOICE_CALL, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
     ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
 
-    override fun getMode() = audioManager().mode
+    override fun getMode() = audioManager.mode
 
     override fun releaseAudioFocus(): Boolean =
-        audioManager().abandonAudioFocus(this) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        audioManager.abandonAudioFocus(this) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
 }
 
 internal class AudioFocusManager(
@@ -125,6 +125,5 @@ internal class AudioFocusManager(
 
     fun stop() {
         audioFocusHandler?.onFocusChange = null
-        audioFocusHandler?.releaseAudioFocus()
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* There is a possibility that earlier change from making the audioManager a function call instead of the instance variable causes some devices to not be able to receive call hold status change events
* This PR reverts the function change, so that we can test if the revert fixes the problem

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open the app
* Start a call
* While in the ACS call, receive a parallel call from Whatsapp, or PSTN etc.


## What to Check
Verify that the following are valid
* Verify that all call-on-hold requirements are being met on your device
