### PR TITLE
[Bug] fix call hold crash

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/AudioFocusManager.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/AudioFocusManager.kt
@@ -125,6 +125,5 @@ internal class AudioFocusManager(
 
     fun stop() {
         audioFocusHandler?.onFocusChange = null
-        audioFocusHandler?.releaseAudioFocus()
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes a crash that would be reproduced by quitting the call while the call hold resume button overlay was showing

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open the app, start an ACS call
* Receive another call from another service like PSTN / Whatsapp etc.
* Come back to the ACS sample app; our resume call overlay should be showing
* Quit the call by hardware back button


## What to Check
Verify that the following are valid
* App should no longer crash in this situation
