### PR TITLE
[Bug] bluetooth crash old api

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/AudioSessionManager.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/AudioSessionManager.kt
@@ -289,7 +289,7 @@ internal class AudioSessionManager(
                 audioManager.isBluetoothScoOn = true
                 audioManager.isSpeakerphoneOn = false
             }
-        } catch (exception : Exception) {
+        } catch (exception: Exception) {
             revertToPreviousAudioDevice()
         }
     }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* On old devices, sometimes we get a race condition when the Bluetooth Device can't be switched to.
* This PR catches the Exception and reverts to the previously selected device when this happens.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
