### PR TITLE
[Bug] Mic permission alert fix

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/PermissionManager.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/manager/PermissionManager.kt
@@ -73,14 +73,15 @@ internal class PermissionManager(
     }
 
     private fun getAudioPermissionState(activity: Activity): PermissionStatus {
-
         val audioAccess = isPermissionGranted(Manifest.permission.RECORD_AUDIO)
-        var isAudioPermissionPreviouslyDenied = false
-        if (!audioAccess && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        var isAudioPermissionPreviouslyDenied = previousPermissionState?.audioPermissionState == PermissionStatus.REQUESTING ||
+            previousPermissionState?.audioPermissionState == PermissionStatus.DENIED
+        if (!audioAccess && !isAudioPermissionPreviouslyDenied && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             isAudioPermissionPreviouslyDenied = activity.shouldShowRequestPermissionRationale(
                 Manifest.permission.RECORD_AUDIO
             )
         }
+
         return when {
             audioAccess -> PermissionStatus.GRANTED
             isAudioPermissionPreviouslyDenied -> PermissionStatus.DENIED


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Upon first launch, if user dismisses mic permission alert, mic button was still visible and no message was shown. Now the mic permission state is correctly detected.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid:
Verify mic button is hidden and permission denied message is shown when permission alert is dismissed on first launch.


## Other Information
<!-- Add any other helpful information that may be needed here. -->
