### PR TITLE
[bugfix] Update colour on call-on-hold overlay

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_call_hold_overlay.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_call_hold_overlay.xml
@@ -34,7 +34,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
         android:text="@string/azure_communication_ui_calling_lobby_view_text_waiting_for_host"
-        android:textColor="@color/azure_communication_ui_calling_color_on_background"
+        android:textColor="@color/azure_communication_ui_calling_color_call_on_hold_overlay_text"
         android:textSize="20sp"
         />
 

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_call_hold_overlay.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_call_hold_overlay.xml
@@ -9,7 +9,7 @@
     android:layout_height="0dp"
     android:layout_row="2"
     android:layout_column="0"
-    android:background="@color/azure_communication_ui_calling_color_call_lobby_overlay"
+    android:background="@color/azure_communication_ui_calling_color_status_bar"
     android:clickable="true"
     android:gravity="center"
     android:orientation="vertical"

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-night/azure_communication_ui_calling_colors.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-night/azure_communication_ui_calling_colors.xml
@@ -19,6 +19,7 @@
     <color name="azure_communication_ui_calling_color_on_warning">#141414</color>
     <color name="azure_communication_ui_calling_color_on_success">#141414</color>
     <color name="azure_communication_ui_calling_color_call_lobby_overlay">#99141414</color>
+    <color name="azure_communication_ui_calling_color_call_on_hold_overlay_text">#FFFFFF</color>
     <color name="azure_communication_ui_calling_color_participant_list_mute_mic">#6E6E6E</color>
     <color name="azure_communication_ui_calling_color_status_bar">#000000</color>
     <color name="azure_communication_ui_calling_color_text_primary">#E1E1E1</color>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values/azure_communication_ui_calling_colors.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values/azure_communication_ui_calling_colors.xml
@@ -20,6 +20,7 @@
     <color name="azure_communication_ui_calling_color_on_success">#FFFFFF</color>
     <color name="azure_communication_ui_calling_color_call_leave_overlay">#CC000000</color>
     <color name="azure_communication_ui_calling_color_call_lobby_overlay">#CCFFFFFF</color>
+    <color name="azure_communication_ui_calling_color_call_on_hold_overlay_text">#212121</color>
     <color name="azure_communication_ui_calling_color_participant_list_mute_mic">#919191</color>
     <color name="azure_communication_ui_calling_color_status_bar">#ffffff</color>
     <color name="azure_communication_ui_calling_color_text_primary">#212121</color>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values/azure_communication_ui_calling_colors.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values/azure_communication_ui_calling_colors.xml
@@ -22,7 +22,7 @@
     <color name="azure_communication_ui_calling_color_call_lobby_overlay">#CCFFFFFF</color>
     <color name="azure_communication_ui_calling_color_call_on_hold_overlay_text">#212121</color>
     <color name="azure_communication_ui_calling_color_participant_list_mute_mic">#919191</color>
-    <color name="azure_communication_ui_calling_color_status_bar">#ffffff</color>
+    <color name="azure_communication_ui_calling_color_status_bar">#FFFFFF</color>
     <color name="azure_communication_ui_calling_color_text_primary">#212121</color>
     <color name="azure_communication_ui_calling_color_action_bar_text">#000000</color>
     <color name="azure_communication_ui_calling_color_focus_highlight">#808080</color>


### PR DESCRIPTION
## Purpose
In order to address luminosity issue of overlay for call-on-hold feature, we decided to update the colour to solid colour for both light and dark mode. Also update the text colour on overlay to be same with Figma design.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Pull Request Type
What kind of change does this Pull Request introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist


- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [X] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
Join a call to trigger call on hold overlay to verify the text colour for both light & dark mode.
