### PR TITLE
[Refactor] Wait for join progress indicator to complete when running UI tests

### DIFF
--- a/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/CallingCompositeNetworkTest.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/CallingCompositeNetworkTest.kt
@@ -45,7 +45,7 @@ class CallingCompositeNetworkTest : BaseUiTest() {
         try {
             setupScreen
                 .turnCameraOn()
-                .clickJoinCallButton()
+                .clickJoinCallButton(false)
 
             setupScreen.dismissNetworkLossBanner()
             setupScreen.navigateUpFromSetupScreen()

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/robots/ScreenRobot.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/robots/ScreenRobot.kt
@@ -14,6 +14,16 @@ import java.lang.IllegalStateException
 
 abstract class ScreenRobot<T : ScreenRobot<T>> {
 
+    fun waitUntilViewIdDoesNotExist(
+        @IdRes viewId: Int,
+        idlingResource: ViewIsDisplayedResource = ViewIsDisplayedResource(),
+    ): ViewInteraction {
+        val viewInteraction = idlingResource.waitUntilViewIsDisplayed {
+            UiTestUtils.checkViewIdDoesNotExist(viewId)
+        }
+        return viewInteraction
+    }
+
     fun waitUntilViewIdIsNotDisplayed(
         @IdRes viewId: Int,
         idlingResource: ViewIsDisplayedResource = ViewIsDisplayedResource(),

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/robots/SetupScreenRobot.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/robots/SetupScreenRobot.kt
@@ -112,7 +112,7 @@ class SetupScreenRobot : ScreenRobot<SetupScreenRobot>() {
     }
 
     @Throws(RuntimeException::class)
-    fun clickJoinCallButton(): CallScreenRobot {
+    fun clickJoinCallButton(waitForProgress: Boolean = true): CallScreenRobot {
         val idlingResource = ViewIsDisplayedResource()
         UiTestUtils.run {
             idlingResource.waitUntilViewIsDisplayed {
@@ -123,7 +123,12 @@ class SetupScreenRobot : ScreenRobot<SetupScreenRobot>() {
             }
             clickViewWithId(R.id.azure_communication_ui_setup_join_call_button)
         }
-
+        if (waitForProgress) {
+            waitUntilViewIdDoesNotExist(
+                R.id.azure_communication_ui_setup_start_call_progress_bar,
+                idlingResource
+            )
+        }
         return CallScreenRobot()
     }
 

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/util/UiTestUtils.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/util/UiTestUtils.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
@@ -59,6 +60,9 @@ object UiTestUtils {
     @Throws(NoMatchingViewException::class)
     fun checkViewIdIsNotDisplayed(@IdRes viewId: Int): ViewInteraction =
         onView(withId(viewId)).check(ViewAssertions.matches(not(isDisplayed())))
+
+    fun checkViewIdDoesNotExist(@IdRes viewId: Int): ViewInteraction =
+        onView(withId(viewId)).check(doesNotExist())
 
     @Throws(NoMatchingViewException::class)
     fun checkViewIdWithContentDescriptionIsDisplayed(


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Wait for join progress indicator to complete when running UI tests

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* run all UI Tests

## What to Check
Verify that the following are valid
* all UI tests pass

