### PR TITLE
[Bug] Display DrawerDialog across screen rotation

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingFragment.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingFragment.kt
@@ -33,6 +33,13 @@ import com.azure.android.communication.ui.calling.presentation.navigation.BackNa
 
 internal class CallingFragment :
     Fragment(R.layout.azure_communication_ui_calling_call_fragment), BackNavigation, SensorEventListener {
+    companion object {
+        private const val TAG = "CallingFragment"
+        private const val LEAVE_CONFIRM_VIEW_KEY = "$TAG.LeaveConfirmView"
+        private const val AUDIO_DEVICE_LIST_VIEW_KEY = "$TAG.AudioDeviceListView"
+        private const val PARTICIPANT_LIST_VIEW_KEY = "$TAG.ParticipantListView"
+
+    }
 
     // Get the DI Container, which gives us what we need for this fragment (dependencies)
     private val holder: DependencyInjectionContainerHolder by activityViewModels()
@@ -194,6 +201,33 @@ internal class CallingFragment :
 
     override fun onBackPressed() {
         requestCallEnd()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        mapOf(
+            LEAVE_CONFIRM_VIEW_KEY to viewModel.getConfirmLeaveOverlayViewModel().getShouldDisplayLeaveConfirmFlow(),
+            AUDIO_DEVICE_LIST_VIEW_KEY to viewModel.getAudioDeviceListViewModel().displayAudioDeviceSelectionMenuStateFlow,
+            PARTICIPANT_LIST_VIEW_KEY to viewModel.getParticipantListViewModel().getDisplayParticipantListStateFlow()
+        ).forEach { (key, element) ->
+            outState.putBoolean(key, element.value)
+        }
+        super.onSaveInstanceState(outState)
+    }
+
+    override fun onViewStateRestored(savedInstanceState: Bundle?) {
+        super.onViewStateRestored(savedInstanceState)
+
+        savedInstanceState?.let {
+            mapOf(
+                LEAVE_CONFIRM_VIEW_KEY to viewModel.getConfirmLeaveOverlayViewModel()::requestExitConfirmation,
+                AUDIO_DEVICE_LIST_VIEW_KEY to viewModel.getAudioDeviceListViewModel()::displayAudioDeviceSelectionMenu,
+                PARTICIPANT_LIST_VIEW_KEY to viewModel.getParticipantListViewModel()::displayParticipantList
+            ).forEach { (key, element) ->
+               if (it.getBoolean(key)) {
+                   element()
+               }
+            }
+        }
     }
 
     private fun requestCallEnd() {

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingFragment.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingFragment.kt
@@ -34,11 +34,9 @@ import com.azure.android.communication.ui.calling.presentation.navigation.BackNa
 internal class CallingFragment :
     Fragment(R.layout.azure_communication_ui_calling_call_fragment), BackNavigation, SensorEventListener {
     companion object {
-        private const val TAG = "CallingFragment"
-        private const val LEAVE_CONFIRM_VIEW_KEY = "$TAG.LeaveConfirmView"
-        private const val AUDIO_DEVICE_LIST_VIEW_KEY = "$TAG.AudioDeviceListView"
-        private const val PARTICIPANT_LIST_VIEW_KEY = "$TAG.ParticipantListView"
-
+        private const val LEAVE_CONFIRM_VIEW_KEY = "LeaveConfirmView"
+        private const val AUDIO_DEVICE_LIST_VIEW_KEY = "AudioDeviceListView"
+        private const val PARTICIPANT_LIST_VIEW_KEY = "ParticipantListView"
     }
 
     // Get the DI Container, which gives us what we need for this fragment (dependencies)
@@ -208,9 +206,7 @@ internal class CallingFragment :
             LEAVE_CONFIRM_VIEW_KEY to viewModel.getConfirmLeaveOverlayViewModel().getShouldDisplayLeaveConfirmFlow(),
             AUDIO_DEVICE_LIST_VIEW_KEY to viewModel.getAudioDeviceListViewModel().displayAudioDeviceSelectionMenuStateFlow,
             PARTICIPANT_LIST_VIEW_KEY to viewModel.getParticipantListViewModel().getDisplayParticipantListStateFlow()
-        ).forEach { (key, element) ->
-            outState.putBoolean(key, element.value)
-        }
+        ).forEach { (key, element) -> outState.putBoolean(key, element.value) }
         super.onSaveInstanceState(outState)
     }
 
@@ -222,11 +218,7 @@ internal class CallingFragment :
                 LEAVE_CONFIRM_VIEW_KEY to viewModel.getConfirmLeaveOverlayViewModel()::requestExitConfirmation,
                 AUDIO_DEVICE_LIST_VIEW_KEY to viewModel.getAudioDeviceListViewModel()::displayAudioDeviceSelectionMenu,
                 PARTICIPANT_LIST_VIEW_KEY to viewModel.getParticipantListViewModel()::displayParticipantList
-            ).forEach { (key, element) ->
-               if (it.getBoolean(key)) {
-                   element()
-               }
-            }
+            ).forEach { (key, showDialog) -> if (it.getBoolean(key)) showDialog() }
         }
     }
 

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmView.kt
@@ -41,10 +41,8 @@ internal class LeaveConfirmView(
     fun stop() {
         bottomCellAdapter.setBottomCellItems(mutableListOf())
         leaveConfirmMenuTable.layoutManager = null
-        if (leaveConfirmMenuDrawer.isShowing) {
-            leaveConfirmMenuDrawer.dismissDialog()
-            viewModel.requestExitConfirmation()
-        }
+        leaveConfirmMenuDrawer.dismissDialog()
+
         removeAllViews()
     }
 

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmView.kt
@@ -41,6 +41,7 @@ internal class LeaveConfirmView(
     fun stop() {
         bottomCellAdapter.setBottomCellItems(mutableListOf())
         leaveConfirmMenuTable.layoutManager = null
+        leaveConfirmMenuDrawer.dismiss()
         leaveConfirmMenuDrawer.dismissDialog()
 
         removeAllViews()

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participantlist/ParticipantListView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participantlist/ParticipantListView.kt
@@ -83,6 +83,7 @@ internal class ParticipantListView(
         participantListDrawer.setOnDismissListener(null)
         bottomCellAdapter.setBottomCellItems(mutableListOf())
         participantTable.layoutManager = null
+        participantListDrawer.dismiss()
         participantListDrawer.dismissDialog()
         this.removeAllViews()
     }

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participantlist/ParticipantListView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participantlist/ParticipantListView.kt
@@ -83,9 +83,7 @@ internal class ParticipantListView(
         participantListDrawer.setOnDismissListener(null)
         bottomCellAdapter.setBottomCellItems(mutableListOf())
         participantTable.layoutManager = null
-        if (participantListDrawer.isShowing) {
-            participantListDrawer.dismissDialog()
-        }
+        participantListDrawer.dismissDialog()
         this.removeAllViews()
     }
 

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
@@ -63,6 +63,7 @@ internal class AudioDeviceListView(
     fun stop() {
         bottomCellAdapter.setBottomCellItems(mutableListOf())
         deviceTable.layoutManager = null
+        audioDeviceDrawer.dismiss()
         audioDeviceDrawer.dismissDialog()
         this.removeAllViews()
     }

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
@@ -63,10 +63,7 @@ internal class AudioDeviceListView(
     fun stop() {
         bottomCellAdapter.setBottomCellItems(mutableListOf())
         deviceTable.layoutManager = null
-        if (audioDeviceDrawer.isShowing) {
-            audioDeviceDrawer.dismissDialog()
-            viewModel.displayAudioDeviceSelectionMenu()
-        }
+        audioDeviceDrawer.dismissDialog()
         this.removeAllViews()
     }
 

--- a/azure-communication-ui/gradle.properties
+++ b/azure-communication-ui/gradle.properties
@@ -21,4 +21,3 @@ android.enableJetifier=true
 kotlin.code.style=official
 # prevent build failures when ADO Pipeline builds the test APK
 android.useNewApkCreator=false
-org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk-11.0.13.jdk/Contents/Home

--- a/azure-communication-ui/gradle.properties
+++ b/azure-communication-ui/gradle.properties
@@ -21,3 +21,4 @@ android.enableJetifier=true
 kotlin.code.style=official
 # prevent build failures when ADO Pipeline builds the test APK
 android.useNewApkCreator=false
+org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk-11.0.13.jdk/Contents/Home


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* DrawerDialog sometimes does not display across screen rotation.  This PR fixes that
* Also fix a memory leak with DrawerDialog

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [x] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [x] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [x] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* join call
* show participant list
* rotate screen a few times
* leave call
* join call
* show audio device list
* rotate screen a few times
* leave call


## What to Check
Verify that the following are valid
* Verify in LogCat that the following message is not displayed:  
`      W/System: A resource failed to call dispose. `

