### PR TITLE
[Bug] Fix participant name not truncating with ellipses in participant list

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_bottom_drawer_cell.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_bottom_drawer_cell.xml
@@ -30,20 +30,28 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         />
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/barrier_start_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="end"
+        app:constraint_referenced_ids="cell_icon, azure_communication_ui_participant_list_avatar"
+        />
 
     <TextView
         android:id="@+id/cell_text"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="72dp"
-        android:layout_marginEnd="40dp"
         android:ellipsize="end"
         android:singleLine="true"
         android:text="@string/azure_communication_ui_calling_audio_device_drawer_android"
         android:textColor="@color/azure_communication_ui_calling_toggle_selector"
+        android:layout_marginStart="12dp"
+        android:layout_marginEnd="12dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toEndOf="@id/barrier_start_icon"
+        app:layout_constraintEnd_toStartOf="@id/barrier_end_icon"
         />
 
     <ImageView
@@ -74,6 +82,14 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/barrier_end_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="start"
+        app:constraint_referenced_ids="cell_check_mark, cell_additional_text"
         />
 
     <ImageView


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes display names not truncating with ellipsis in participant list

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [x] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [x] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open the demo app, and set a _really_ long display name
* Join a call and see how the display name appears in various places like grid and participant list, in different devices and orientations


## What to Check
Verify that the following are valid
* With this PR, the display name will display correctly truncated with an ellipsis in all devices and orientations

## Other Information
The ConstraintLayout now utilizes a [Barrier](https://developer.android.com/reference/androidx/constraintlayout/widget/Barrier) to encapsulate the start and end point of the main `TextView` in the menu cell, to allow the main TextView to accommodate any of the menu images showing (or not).

## Screenshots
![Screenshot_1656443055](https://user-images.githubusercontent.com/43901/176322548-1d3654e1-d3e7-4d45-a73c-31b3e463c8ed.png)
![Screenshot_1656443032](https://user-images.githubusercontent.com/43901/176322785-c2cd8b78-c83d-4625-8617-f13a1ee59bdc.png)
![Screenshot_1656442939](https://user-images.githubusercontent.com/43901/176322812-e878fc93-cc01-40ca-ac34-75dc7f2010a0.png)

