### PR TITLE
[Bug] Fix Accessibility focus issue for call on hold overlay

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingViewModel.kt
@@ -202,15 +202,15 @@ internal class CallingViewModel(
                 state.callState
             )
         }
-        updateLobbyOverlayDisplayedState(state.callState.callingStatus)
+        updateOverlayDisplayedState(state.callState.callingStatus)
     }
 
     private fun shouldUpdateRemoteParticipantsViewModels(state: ReduxState) =
         state.callState.callingStatus == CallingStatus.CONNECTED
 
-    private fun updateLobbyOverlayDisplayedState(callingStatus: CallingStatus) {
-        floatingHeaderViewModel.updateIsLobbyOverlayDisplayed(callingStatus)
-        bannerViewModel.updateIsLobbyOverlayDisplayed(callingStatus)
-        localParticipantViewModel.updateIsLobbyOverlayDisplayed(callingStatus)
+    private fun updateOverlayDisplayedState(callingStatus: CallingStatus) {
+        floatingHeaderViewModel.updateIsOverlayDisplayed(callingStatus)
+        bannerViewModel.updateIsOverlayDisplayed(callingStatus)
+        localParticipantViewModel.updateIsOverlayDisplayed(callingStatus)
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/banner/BannerView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/banner/BannerView.kt
@@ -53,7 +53,7 @@ internal class BannerView : ConstraintLayout {
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.getIsLobbyOverlayDisplayedFlow().collect {
+            viewModel.getIsOverlayDisplayedFlow().collect {
                 if (it) {
                     ViewCompat.setImportantForAccessibility(bannerView, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
                 } else {

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/banner/BannerViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/banner/BannerViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.StateFlow
 internal class BannerViewModel {
 
     private lateinit var bannerInfoTypeStateFlow: MutableStateFlow<BannerInfoType>
-    private lateinit var isLobbyOverlayDisplayedFlow: MutableStateFlow<Boolean>
+    private lateinit var isOverlayDisplayedFlow: MutableStateFlow<Boolean>
     private var shouldShowBannerStateFlow = MutableStateFlow(false)
 
     private var recordingState: ComplianceState = ComplianceState.OFF
@@ -19,7 +19,7 @@ internal class BannerViewModel {
 
     private var displayedBannerType: BannerInfoType = BannerInfoType.BLANK
 
-    fun getIsLobbyOverlayDisplayedFlow(): StateFlow<Boolean> = isLobbyOverlayDisplayedFlow
+    fun getIsOverlayDisplayedFlow(): StateFlow<Boolean> = isOverlayDisplayedFlow
 
     fun getBannerInfoTypeStateFlow(): StateFlow<BannerInfoType> {
         return bannerInfoTypeStateFlow
@@ -35,11 +35,11 @@ internal class BannerViewModel {
         bannerInfoTypeStateFlow = MutableStateFlow(
             createBannerInfoType(callingState.isRecording, callingState.isTranscribing)
         )
-        isLobbyOverlayDisplayedFlow = MutableStateFlow(isLobbyOverlayDisplayed(callingState.callingStatus))
+        isOverlayDisplayedFlow = MutableStateFlow(isOverlayDisplayed(callingState.callingStatus))
     }
 
-    fun updateIsLobbyOverlayDisplayed(callingStatus: CallingStatus) {
-        isLobbyOverlayDisplayedFlow.value = isLobbyOverlayDisplayed(callingStatus)
+    fun updateIsOverlayDisplayed(callingStatus: CallingStatus) {
+        isOverlayDisplayedFlow.value = isOverlayDisplayed(callingStatus)
     }
 
     fun update(callingState: CallingState) {
@@ -140,8 +140,8 @@ internal class BannerViewModel {
         }
     }
 
-    private fun isLobbyOverlayDisplayed(callingStatus: CallingStatus) =
-        callingStatus == CallingStatus.IN_LOBBY
+    private fun isOverlayDisplayed(callingStatus: CallingStatus) =
+        callingStatus == CallingStatus.IN_LOBBY || callingStatus == CallingStatus.LOCAL_HOLD
 }
 
 internal enum class ComplianceState {

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/header/InfoHeaderView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/header/InfoHeaderView.kt
@@ -75,7 +75,7 @@ internal class InfoHeaderView : ConstraintLayout {
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
-            infoHeaderViewModel.getIsLobbyOverlayDisplayedFlow().collect {
+            infoHeaderViewModel.getIsOverlayDisplayedFlow().collect {
                 if (it) {
                     ViewCompat.setImportantForAccessibility(headerView, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
                 } else {

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/header/InfoHeaderViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/header/InfoHeaderViewModel.kt
@@ -11,14 +11,14 @@ import java.util.TimerTask
 
 internal class InfoHeaderViewModel {
     private lateinit var displayFloatingHeaderFlow: MutableStateFlow<Boolean>
-    private lateinit var isLobbyOverlayDisplayedFlow: MutableStateFlow<Boolean>
+    private lateinit var isOverlayDisplayedFlow: MutableStateFlow<Boolean>
     private lateinit var numberOfParticipantsFlow: MutableStateFlow<Int>
 
     private lateinit var timer: Timer
 
     private var displayedOnLaunch = false
 
-    fun getIsLobbyOverlayDisplayedFlow(): StateFlow<Boolean> = isLobbyOverlayDisplayedFlow
+    fun getIsOverlayDisplayedFlow(): StateFlow<Boolean> = isOverlayDisplayedFlow
 
     fun getDisplayFloatingHeaderFlow(): StateFlow<Boolean> = displayFloatingHeaderFlow
 
@@ -36,8 +36,8 @@ internal class InfoHeaderViewModel {
         }
     }
 
-    fun updateIsLobbyOverlayDisplayed(callingStatus: CallingStatus) {
-        isLobbyOverlayDisplayedFlow.value = isLobbyOverlayDisplayed(callingStatus)
+    fun updateIsOverlayDisplayed(callingStatus: CallingStatus) {
+        isOverlayDisplayedFlow.value = isOverlayDisplayed(callingStatus)
     }
 
     fun init(
@@ -47,7 +47,7 @@ internal class InfoHeaderViewModel {
         timer = Timer()
         displayFloatingHeaderFlow = MutableStateFlow(false)
         numberOfParticipantsFlow = MutableStateFlow(numberOfRemoteParticipants)
-        isLobbyOverlayDisplayedFlow = MutableStateFlow(isLobbyOverlayDisplayed(callingStatus))
+        isOverlayDisplayedFlow = MutableStateFlow(isOverlayDisplayed(callingStatus))
     }
 
     fun switchFloatingHeader() {
@@ -76,6 +76,6 @@ internal class InfoHeaderViewModel {
         }
     }
 
-    private fun isLobbyOverlayDisplayed(callingStatus: CallingStatus) =
-        callingStatus == CallingStatus.IN_LOBBY
+    private fun isOverlayDisplayed(callingStatus: CallingStatus) =
+        callingStatus == CallingStatus.IN_LOBBY || callingStatus == CallingStatus.LOCAL_HOLD
 }

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantView.kt
@@ -165,7 +165,7 @@ internal class LocalParticipantView : ConstraintLayout {
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.getIsLobbyOverlayDisplayedFlow().collect {
+            viewModel.getIsOverlayDisplayedFlow().collect {
                 if (it) {
                     ViewCompat.setImportantForAccessibility(
                         switchCameraButton,

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantViewModel.kt
@@ -27,7 +27,7 @@ internal class LocalParticipantViewModel(
     private lateinit var displayPipSwitchCameraButtonFlow: MutableStateFlow<Boolean>
     private lateinit var enableCameraSwitchFlow: MutableStateFlow<Boolean>
     private lateinit var cameraDeviceSelectionFlow: MutableStateFlow<CameraDeviceSelectionStatus>
-    private lateinit var isLobbyOverlayDisplayedFlow: MutableStateFlow<Boolean>
+    private lateinit var isOverlayDisplayedFlow: MutableStateFlow<Boolean>
     private lateinit var numberOfRemoteParticipantsFlow: MutableStateFlow<Int>
 
     fun getVideoStatusFlow(): StateFlow<VideoModel> = videoStatusFlow
@@ -101,18 +101,18 @@ internal class LocalParticipantViewModel(
             cameraDeviceSelectionStatus != CameraDeviceSelectionStatus.SWITCHING
         )
         cameraDeviceSelectionFlow = MutableStateFlow(cameraDeviceSelectionStatus)
-        isLobbyOverlayDisplayedFlow = MutableStateFlow(isLobbyOverlayDisplayed(callingState))
+        isOverlayDisplayedFlow = MutableStateFlow(isOverlayDisplayed(callingState))
         numberOfRemoteParticipantsFlow = MutableStateFlow(numberOfRemoteParticipants)
     }
 
     fun switchCamera() = dispatch(LocalParticipantAction.CameraSwitchTriggered())
 
-    fun getIsLobbyOverlayDisplayedFlow(): StateFlow<Boolean> = isLobbyOverlayDisplayedFlow
+    fun getIsOverlayDisplayedFlow(): StateFlow<Boolean> = isOverlayDisplayedFlow
 
     fun getNumberOfRemoteParticipantsFlow(): StateFlow<Int> = numberOfRemoteParticipantsFlow
 
-    fun updateIsLobbyOverlayDisplayed(callingStatus: CallingStatus) {
-        isLobbyOverlayDisplayedFlow.value = isLobbyOverlayDisplayed(callingStatus)
+    fun updateIsOverlayDisplayed(callingStatus: CallingStatus) {
+        isOverlayDisplayedFlow.value = isOverlayDisplayed(callingStatus)
     }
 
     private fun shouldDisplayVideo(videoStreamID: String?) = videoStreamID != null
@@ -132,8 +132,8 @@ internal class LocalParticipantViewModel(
             LocalParticipantViewMode.PIP else LocalParticipantViewMode.FULL_SCREEN
     }
 
-    private fun isLobbyOverlayDisplayed(callingStatus: CallingStatus) =
-        callingStatus == CallingStatus.IN_LOBBY
+    private fun isOverlayDisplayed(callingStatus: CallingStatus) =
+        callingStatus == CallingStatus.IN_LOBBY || callingStatus == CallingStatus.LOCAL_HOLD
 
     internal data class VideoModel(
         val shouldDisplayVideo: Boolean,

--- a/azure-communication-ui/azure-communication-ui/src/testCalling/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderViewModelUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/testCalling/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderViewModelUnitTest.kt
@@ -115,7 +115,7 @@ internal class InfoHeaderViewModelUnitTest : ACSBaseTestCoroutine() {
                 mutableListOf<Boolean>()
 
             val flowJob = launch {
-                floatingHeaderViewModel.getIsLobbyOverlayDisplayedFlow()
+                floatingHeaderViewModel.getIsOverlayDisplayedFlow()
                     .toList(resultListFromIsLobbyOverlayDisplayedFlow)
             }
 

--- a/azure-communication-ui/azure-communication-ui/src/testCalling/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderViewModelUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/testCalling/java/com/azure/android/communication/ui/presentation/fragment/calling/header/InfoHeaderViewModelUnitTest.kt
@@ -120,8 +120,8 @@ internal class InfoHeaderViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             // act
-            floatingHeaderViewModel.updateIsLobbyOverlayDisplayed(CallingStatus.CONNECTED)
-            floatingHeaderViewModel.updateIsLobbyOverlayDisplayed(CallingStatus.IN_LOBBY)
+            floatingHeaderViewModel.updateIsOverlayDisplayed(CallingStatus.CONNECTED)
+            floatingHeaderViewModel.updateIsOverlayDisplayed(CallingStatus.IN_LOBBY)
 
             // assert
             Assert.assertEquals(


### PR DESCRIPTION
## Purpose
When call on hold overlay is up, Talkback should not focus on the hidden UI elements behind the overlay. So I made this change to fix the issue.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Pull Request Type
What kind of change does this Pull Request introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
Join a group call with Talkback on, receive a call/break from another App to trigger call on hold. Then swipe to verify the Talkback focus on the overlay.