### PR TITLE
[Refactor] Android Studio no longer complains about usage of flatDir

### DIFF
--- a/azure-communication-ui/azure-communication-ui-demo-app/build.gradle
+++ b/azure-communication-ui/azure-communication-ui-demo-app/build.gradle
@@ -125,12 +125,6 @@ android {
     }
 }
 
-repositories {
-    flatDir{
-        dirs "lib"
-    }
-}
-
 dependencies {
     def app_center_sdk_version = '4.1.0'
     implementation project(path: ':azure-communication-ui')
@@ -141,11 +135,11 @@ dependencies {
     implementation 'com.google.android.material:material:1.6.1'
     implementation "androidx.constraintlayout:constraintlayout:$androidx_constraint_layout_version"
     implementation 'com.github.kittinunf.fuel:fuel:2.3.1'
-    implementation(name: "magnifier-0.0.17", ext: 'aar')
     implementation "com.microsoft.appcenter:appcenter-analytics:$app_center_sdk_version"
     implementation "com.microsoft.appcenter:appcenter-crashes:$app_center_sdk_version"
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation "com.microsoft.appcenter:appcenter-distribute:$app_center_sdk_version"
+    implementation files('lib/magnifier-0.0.17.aar')
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
     testImplementation "junit:junit:$junit_version"
     androidTestImplementation('com.microsoft.appcenter:espresso-test-extension:1.4')


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [x] Other... Please describe:
Fixes a build time warning about usage of flatDirs
## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open the project in Android Studio
* Do a clean and rebuild from the Build menu


## What to Check
Verify that the following are valid
* Android Studio should no longer complain about the magnifier lib that was earlier being loaded using flatDir, which is now being loaded using the normal `implementation` with a `files` function call.

