### PR TITLE
[Bug] Announcing remote pariticipant on hold in talkback

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participantlist/ParticipantListView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participantlist/ParticipantListView.kt
@@ -213,12 +213,12 @@ internal class ParticipantListView(
             else R.string.azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label
         )
 
-        val onHoldText: String = if (isOnHold) "on hold" else ""
+        val onHoldAnnouncement: String = if (isOnHold) context.getString(R.string.azure_communication_ui_calling_remote_participant_on_hold) else ""
 
         return BottomCellItem(
             null,
             displayName,
-            displayName + context.getString(R.string.azure_communication_ui_calling_view_participant_list_dismiss_list) + onHoldText,
+            displayName + context.getString(R.string.azure_communication_ui_calling_view_participant_list_dismiss_list) + onHoldAnnouncement,
             micIcon,
             R.color.azure_communication_ui_calling_color_participant_list_mute_mic,
             micAccessibilityAnnouncement,

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participantlist/ParticipantListView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participantlist/ParticipantListView.kt
@@ -213,10 +213,12 @@ internal class ParticipantListView(
             else R.string.azure_communication_ui_calling_view_participant_list_unmuted_accessibility_label
         )
 
+        val onHoldText: String = if (isOnHold) "on hold" else ""
+
         return BottomCellItem(
             null,
             displayName,
-            displayName + context.getString(R.string.azure_communication_ui_calling_view_participant_list_dismiss_list),
+            displayName + context.getString(R.string.azure_communication_ui_calling_view_participant_list_dismiss_list) + onHoldText,
             micIcon,
             R.color.azure_communication_ui_calling_color_participant_list_mute_mic,
             micAccessibilityAnnouncement,


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Announcing on hold speech for the remote participant in the participant list view

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* Verify if talkback announces on hold after announcing participant's name in the participant list drawer

## Other Information
<!-- Add any other helpful information that may be needed here. -->
[Bug 2916996](https://skype.visualstudio.com/SPOOL/_workitems/edit/2916996): [ACS Mobile UI Android-Call on Hold]: Talkback is not announcing status message as 'On hold' for particular participant in the participant list.

