### PR TITLE
refactor: prefix all non-conforming ui elements with azure_communication_ui_

### DIFF
--- a/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/matchers/BottomCellViewHolderMatcher.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/matchers/BottomCellViewHolderMatcher.kt
@@ -24,8 +24,8 @@ class BottomCellViewHolderMatcher(
 
     override fun matchesSafely(item: RecyclerView.ViewHolder?): Boolean {
         val holderRoot = item?.itemView ?: return false
-        val checkMark: ImageView = holderRoot.findViewById(R.id.cell_check_mark)
-        val audioDeviceTextView: TextView = holderRoot.findViewById(R.id.cell_text)
+        val checkMark: ImageView = holderRoot.findViewById(R.id.azure_communication_ui_cell_check_mark)
+        val audioDeviceTextView: TextView = holderRoot.findViewById(R.id.azure_communication_ui_cell_text)
 
         // helps to click after delay
         // on API 31, test case will fail if delay is removed

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/robots/CallScreenRobot.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/robots/CallScreenRobot.kt
@@ -52,9 +52,9 @@ class CallScreenRobot : ScreenRobot<CallScreenRobot>() {
 
     fun checkFirstParticipantInList(): CallScreenRobot {
         val viewIds = Triple(
-            R.id.cell_icon,
+            R.id.azure_communication_ui_cell_icon,
             R.id.azure_communication_ui_participant_list_avatar,
-            R.id.cell_text
+            R.id.azure_communication_ui_cell_text
         )
         UiTestUtils.check3IemRecyclerViewHolderAtPosition(R.id.bottom_drawer_table, 0, viewIds)
         return this
@@ -96,7 +96,7 @@ class CallScreenRobot : ScreenRobot<CallScreenRobot>() {
             UiTestUtils.checkViewWithTextIsDisplayed("Leave call?")
         }
         onView(withId(R.id.bottom_drawer_table)).perform(swipeUp())
-        UiTestUtils.clickViewWithIdAndText(R.id.cell_text, "Leave")
+        UiTestUtils.clickViewWithIdAndText(R.id.azure_communication_ui_cell_text, "Leave")
     }
 
     fun verifyFirstParticipantName(userName: String): CallScreenRobot {
@@ -104,7 +104,7 @@ class CallScreenRobot : ScreenRobot<CallScreenRobot>() {
         UiTestUtils.checkRecyclerViewViewHolderText(
             R.id.bottom_drawer_table,
             0,
-            R.id.cell_text,
+            R.id.azure_communication_ui_cell_text,
             userName
         )
         return this

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/robots/SetupScreenRobot.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/androidTest/java/com/azure/android/communication/ui/callingcompositedemoapp/robots/SetupScreenRobot.kt
@@ -70,7 +70,7 @@ class SetupScreenRobot : ScreenRobot<SetupScreenRobot>() {
     }
 
     private fun selectAudioDevice(@DrawableRes iconId: Int, text: String, isSelected: Boolean) {
-        val audioDeviceList = waitUntilAllViewIdIsAreDisplayed(R.id.cell_text)
+        val audioDeviceList = waitUntilAllViewIdIsAreDisplayed(R.id.azure_communication_ui_cell_text)
         UiTestUtils.clickBottomCellViewHolder(R.id.bottom_drawer_table, iconId, text, isSelected)
     }
 

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/utilities/BottomCellActionViewHolder.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/utilities/BottomCellActionViewHolder.kt
@@ -14,11 +14,11 @@ import com.azure.android.communication.ui.R
 import com.microsoft.fluentui.persona.AvatarView
 
 internal class BottomCellActionViewHolder(itemView: View) : BottomCellViewHolder(itemView) {
-    private val imageView: ImageView = itemView.findViewById(R.id.cell_icon)
+    private val imageView: ImageView = itemView.findViewById(R.id.azure_communication_ui_cell_icon)
     private val avatarView: AvatarView =
         itemView.findViewById(R.id.azure_communication_ui_participant_list_avatar)
-    private val accessoryImageView: ImageView = itemView.findViewById(R.id.cell_check_mark)
-    private val additionalText: TextView = itemView.findViewById(R.id.cell_additional_text)
+    private val accessoryImageView: ImageView = itemView.findViewById(R.id.azure_communication_ui_cell_check_mark)
+    private val additionalText: TextView = itemView.findViewById(R.id.azure_communication_ui_cell_additional_text)
 
     override fun setCellData(bottomCellItem: BottomCellItem) {
         super.setCellData(bottomCellItem)

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/utilities/BottomCellViewHolder.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/utilities/BottomCellViewHolder.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.azure.android.communication.ui.R
 
 internal open class BottomCellViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-    private val title: TextView = itemView.findViewById(R.id.cell_text)
+    private val title: TextView = itemView.findViewById(R.id.azure_communication_ui_cell_text)
     open fun setCellData(bottomCellItem: BottomCellItem) {
         title.text = bottomCellItem.title
         itemView.contentDescription = bottomCellItem.contentDescription

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/layout-land/azure_communication_ui_calling_call_fragment.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/layout-land/azure_communication_ui_calling_call_fragment.xml
@@ -5,7 +5,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/frameLayout2"
+    android:id="@+id/azure_communication_ui_frameLayout2"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:alpha="1"

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/layout-sw600dp-land/azure_communication_ui_calling_call_fragment.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/layout-sw600dp-land/azure_communication_ui_calling_call_fragment.xml
@@ -5,7 +5,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/frameLayout2"
+    android:id="@+id/azure_communication_ui_frameLayout2"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:alpha="1"

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_bottom_drawer_cell.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_bottom_drawer_cell.xml
@@ -9,7 +9,7 @@
     >
 
     <ImageView
-        android:id="@+id/cell_icon"
+        android:id="@+id/azure_communication_ui_cell_icon"
         android:layout_width="20dp"
         android:layout_height="20dp"
         android:layout_marginStart="18dp"
@@ -31,15 +31,15 @@
         app:layout_constraintTop_toTopOf="parent"
         />
     <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/barrier_start_icon"
+        android:id="@+id/azure_communication_ui_barrier_start_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="end"
-        app:constraint_referenced_ids="cell_icon, azure_communication_ui_participant_list_avatar"
+        app:constraint_referenced_ids="azure_communication_ui_cell_icon, azure_communication_ui_participant_list_avatar"
         />
 
     <TextView
-        android:id="@+id/cell_text"
+        android:id="@+id/azure_communication_ui_cell_text"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:ellipsize="end"
@@ -50,12 +50,12 @@
         android:layout_marginEnd="12dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toEndOf="@id/barrier_start_icon"
-        app:layout_constraintEnd_toStartOf="@id/barrier_end_icon"
+        app:layout_constraintStart_toEndOf="@id/azure_communication_ui_barrier_start_icon"
+        app:layout_constraintEnd_toStartOf="@id/azure_communication_ui_barrier_end_icon"
         />
 
     <ImageView
-        android:id="@+id/cell_check_mark"
+        android:id="@+id/azure_communication_ui_cell_check_mark"
         android:layout_width="20dp"
         android:layout_height="20dp"
         android:layout_marginEnd="12dp"
@@ -70,7 +70,7 @@
         />
 
     <TextView
-        android:id="@+id/cell_additional_text"
+        android:id="@+id/azure_communication_ui_cell_additional_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="12dp"
@@ -85,11 +85,11 @@
         />
 
     <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/barrier_end_icon"
+        android:id="@+id/azure_communication_ui_barrier_end_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="start"
-        app:constraint_referenced_ids="cell_check_mark, cell_additional_text"
+        app:constraint_referenced_ids="azure_communication_ui_cell_check_mark, azure_communication_ui_cell_additional_text"
         />
 
     <ImageView

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_bottom_drawer_title_cell.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_bottom_drawer_title_cell.xml
@@ -8,7 +8,7 @@
     android:layout_height="wrap_content"
     >
     <TextView
-        android:id="@+id/cell_text"
+        android:id="@+id/azure_communication_ui_cell_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="18dp"

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_call_fragment.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_call_fragment.xml
@@ -5,7 +5,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/frameLayout2"
+    android:id="@+id/azure_communication_ui_frameLayout2"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:alpha="1"


### PR DESCRIPTION

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Refactored UI elements that did not have the prefix azure_communication_ui_ to now have it

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open the app and run through sanity / smoke testing


## What to Check
Verify that the following are valid
* No UI changes or new effects should be visible

## Other Information
<!-- Add any other helpful information that may be needed here. -->
