### PR TITLE
[Feature] Receive error event when device manager throws any error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
 # Release History
 
 [Communication UI Calling Library CHANGELOG](docs/CHANGELOG_UI_CALLING.md)
+
+### Features
+- New error code 'unknownError' introduced for ambiguous errors such as device manager error 

--- a/azure-communication-ui/azure-communication-ui/src/androidTest/java/com/azure/android/communication/mocking/TestCallingSDK.kt
+++ b/azure-communication-ui/azure-communication-ui/src/androidTest/java/com/azure/android/communication/mocking/TestCallingSDK.kt
@@ -4,7 +4,13 @@
 package com.azure.android.communication.mocking
 
 import androidx.annotation.GuardedBy
-import com.azure.android.communication.calling.*
+import com.azure.android.communication.calling.CameraFacing
+import com.azure.android.communication.calling.VideoDeviceType
+import com.azure.android.communication.calling.ParticipantState
+import com.azure.android.communication.calling.MediaStreamType
+import com.azure.android.communication.calling.CallState
+import com.azure.android.communication.calling.RemoteVideoStreamsUpdatedListener
+import com.azure.android.communication.calling.PropertyChangedListener
 import com.azure.android.communication.ui.calling.models.ParticipantInfoModel
 import com.azure.android.communication.ui.calling.models.StreamType
 import com.azure.android.communication.ui.calling.models.VideoStreamModel
@@ -71,8 +77,6 @@ internal class TestCallingSDK(private val callEvents: CallEvents, coroutineConte
 
     private var localCameraFacing = CameraFacing.FRONT
     private val localVideoStream = LocalVideoStreamTest(callEvents, localCameraFacing, coroutineScope)
-
-    private lateinit var deviceManager: DeviceManager
 
     suspend fun addRemoteParticipant(
         id: CommunicationIdentifier,

--- a/azure-communication-ui/azure-communication-ui/src/androidTest/java/com/azure/android/communication/mocking/TestCallingSDK.kt
+++ b/azure-communication-ui/azure-communication-ui/src/androidTest/java/com/azure/android/communication/mocking/TestCallingSDK.kt
@@ -4,13 +4,7 @@
 package com.azure.android.communication.mocking
 
 import androidx.annotation.GuardedBy
-import com.azure.android.communication.calling.CallState
-import com.azure.android.communication.calling.CameraFacing
-import com.azure.android.communication.calling.MediaStreamType
-import com.azure.android.communication.calling.ParticipantState
-import com.azure.android.communication.calling.PropertyChangedListener
-import com.azure.android.communication.calling.RemoteVideoStreamsUpdatedListener
-import com.azure.android.communication.calling.VideoDeviceType
+import com.azure.android.communication.calling.*
 import com.azure.android.communication.ui.calling.models.ParticipantInfoModel
 import com.azure.android.communication.ui.calling.models.StreamType
 import com.azure.android.communication.ui.calling.models.VideoStreamModel
@@ -78,6 +72,8 @@ internal class TestCallingSDK(private val callEvents: CallEvents, coroutineConte
     private var localCameraFacing = CameraFacing.FRONT
     private val localVideoStream = LocalVideoStreamTest(callEvents, localCameraFacing, coroutineScope)
 
+    private lateinit var deviceManager: DeviceManager
+
     suspend fun addRemoteParticipant(
         id: CommunicationIdentifier,
         displayName: String,
@@ -137,7 +133,9 @@ internal class TestCallingSDK(private val callEvents: CallEvents, coroutineConte
         emitRemoteParticipantFlow()
     }
 
-    override fun setupCall() {}
+    override fun setupCall(): CompletableFuture<Void> {
+        return completedNullFuture()
+    }
     override fun dispose() {}
 
     override fun turnOnVideoAsync(): CompletableFuture<LocalVideoStream> {

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorCode.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorCode.kt
@@ -14,6 +14,7 @@ internal class ErrorCode : ExpandableStringEnum<ErrorCode?>() {
         val TURN_CAMERA_OFF_FAILED = fromString("turnCameraOffFailed")
         val TURN_MIC_ON_FAILED = fromString("turnMicOnFailed")
         val TURN_MIC_OFF_FAILED = fromString("turnMicOffFailed")
+        val UNKNOWN_ERROR = fromString("unknownError")
 
         private fun fromString(name: String): ErrorCode {
             return fromString(name, ErrorCode::class.java)

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorHandler.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorHandler.kt
@@ -3,6 +3,7 @@
 
 package com.azure.android.communication.ui.calling.error
 
+import android.util.Log
 import com.azure.android.communication.ui.calling.configuration.CallCompositeConfiguration
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.CALL_END_FAILED
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.CALL_JOIN_FAILED
@@ -10,6 +11,7 @@ import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.SWIT
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TOKEN_EXPIRED
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TURN_CAMERA_OFF_FAILED
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TURN_CAMERA_ON_FAILED
+import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.UNKNOWN_ERROR
 import com.azure.android.communication.ui.calling.models.CallCompositeErrorCode
 import com.azure.android.communication.ui.calling.models.CallCompositeErrorEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeEventCode
@@ -113,10 +115,14 @@ internal class ErrorHandler(
     }
 
     private fun getCallCompositeErrorCode(errorCode: ErrorCode?): CallCompositeErrorCode? {
+        Log.d("Mohtasim", "Error code - " + errorCode.toString())
         errorCode?.let {
             when (it) {
                 TOKEN_EXPIRED -> {
                     return CallCompositeErrorCode.TOKEN_EXPIRED
+                }
+                UNKNOWN_ERROR -> {
+                    return CallCompositeErrorCode.UNKNOWN_ERROR
                 }
                 CALL_JOIN_FAILED -> {
                     return CallCompositeErrorCode.CALL_JOIN_FAILED

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorHandler.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorHandler.kt
@@ -3,7 +3,6 @@
 
 package com.azure.android.communication.ui.calling.error
 
-import android.util.Log
 import com.azure.android.communication.ui.calling.configuration.CallCompositeConfiguration
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.CALL_END_FAILED
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.CALL_JOIN_FAILED
@@ -115,7 +114,6 @@ internal class ErrorHandler(
     }
 
     private fun getCallCompositeErrorCode(errorCode: ErrorCode?): CallCompositeErrorCode? {
-        Log.d("Mohtasim", "Error code - " + errorCode.toString())
         errorCode?.let {
             when (it) {
                 TOKEN_EXPIRED -> {

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorHandler.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorHandler.kt
@@ -11,8 +11,6 @@ import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TOKE
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TURN_CAMERA_OFF_FAILED
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TURN_CAMERA_ON_FAILED
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.UNKNOWN_ERROR
-import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TURN_CAMERA_OFF_FAILED
-import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TURN_CAMERA_ON_FAILED
 import com.azure.android.communication.ui.calling.models.CallCompositeErrorCode
 import com.azure.android.communication.ui.calling.models.CallCompositeErrorEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeEventCode

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorHandler.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorHandler.kt
@@ -11,6 +11,8 @@ import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TOKE
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TURN_CAMERA_OFF_FAILED
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TURN_CAMERA_ON_FAILED
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.UNKNOWN_ERROR
+import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TURN_CAMERA_OFF_FAILED
+import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TURN_CAMERA_ON_FAILED
 import com.azure.android.communication.ui.calling.models.CallCompositeErrorCode
 import com.azure.android.communication.ui.calling.models.CallCompositeErrorEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeEventCode

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeErrorCode.java
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeErrorCode.java
@@ -38,6 +38,11 @@ public final class CallCompositeErrorCode extends ExpandableStringEnum<CallCompo
     public static final CallCompositeErrorCode UNKNOWN_ERROR = fromString("unknownError");
 
     /**
+     * Dispatched when camera failed to start, stop or switch
+     */
+    public static final CallCompositeErrorCode CAMERA_FAILURE = fromString("cameraFailure");
+
+    /**
      * Creates or finds a {@link CallCompositeErrorCode} from its string representation.
      *
      * @param name a name to look for.

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeErrorCode.java
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeErrorCode.java
@@ -27,11 +27,15 @@ public final class CallCompositeErrorCode extends ExpandableStringEnum<CallCompo
      */
     public static final CallCompositeErrorCode TOKEN_EXPIRED = fromString("tokenExpired");
 
-
     /**
      * Dispatched when camera failed to start, stop or switch
      */
     public static final CallCompositeErrorCode CAMERA_FAILURE = fromString("cameraFailure");
+
+    /***
+     * Dispatched when composite falls under any ambiguous state such as device manager instance error
+     */
+    public static final CallCompositeErrorCode UNKNOWN_ERROR = fromString("unknownError");
 
     /**
      * Creates or finds a {@link CallCompositeErrorCode} from its string representation.

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeErrorCode.java
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeErrorCode.java
@@ -38,11 +38,6 @@ public final class CallCompositeErrorCode extends ExpandableStringEnum<CallCompo
     public static final CallCompositeErrorCode UNKNOWN_ERROR = fromString("unknownError");
 
     /**
-     * Dispatched when camera failed to start, stop or switch
-     */
-    public static final CallCompositeErrorCode CAMERA_FAILURE = fromString("cameraFailure");
-
-    /**
      * Creates or finds a {@link CallCompositeErrorCode} from its string representation.
      *
      * @param name a name to look for.

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/redux/action/LocalParticipantAction.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/redux/action/LocalParticipantAction.kt
@@ -9,6 +9,7 @@ import com.azure.android.communication.ui.calling.redux.state.AudioOperationalSt
 import com.azure.android.communication.ui.calling.redux.state.CameraDeviceSelectionStatus
 
 internal sealed class LocalParticipantAction : Action {
+    class DeviceManagerFetchFailed(val error: CallCompositeError) : LocalParticipantAction()
     class CameraPreviewOnRequested : LocalParticipantAction()
     class CameraPreviewOnTriggered : LocalParticipantAction()
     class CameraPreviewOnSucceeded(var videoStreamID: String) : LocalParticipantAction()

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/redux/middleware/handler/CallingMiddlewareActionHandler.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/redux/middleware/handler/CallingMiddlewareActionHandler.kt
@@ -201,8 +201,10 @@ internal class CallingMiddlewareActionHandlerImpl(
     override fun setupCall(store: Store<ReduxState>) {
         callingService.setupCall().handle { _, error: Throwable? ->
             if (error != null) {
-                ErrorAction.FatalErrorOccurred(
-                    FatalError(error, ErrorCode.UNKNOWN_ERROR)
+                store.dispatch(
+                    ErrorAction.FatalErrorOccurred(
+                        FatalError(error, ErrorCode.UNKNOWN_ERROR)
+                    )
                 )
             }
         }

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/redux/middleware/handler/CallingMiddlewareActionHandler.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/redux/middleware/handler/CallingMiddlewareActionHandler.kt
@@ -200,7 +200,7 @@ internal class CallingMiddlewareActionHandlerImpl(
 
     override fun setupCall(store: Store<ReduxState>) {
         callingService.setupCall().handle { _, error: Throwable? ->
-            if(error != null) {
+            if (error != null) {
                 ErrorAction.FatalErrorOccurred(
                     FatalError(error, ErrorCode.UNKNOWN_ERROR)
                 )

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/redux/middleware/handler/CallingMiddlewareActionHandler.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/redux/middleware/handler/CallingMiddlewareActionHandler.kt
@@ -199,7 +199,13 @@ internal class CallingMiddlewareActionHandlerImpl(
     }
 
     override fun setupCall(store: Store<ReduxState>) {
-        callingService.setupCall()
+        callingService.setupCall().handle { _, error: Throwable? ->
+            if(error != null) {
+                ErrorAction.FatalErrorOccurred(
+                    FatalError(error, ErrorCode.UNKNOWN_ERROR)
+                )
+            }
+        }
     }
 
     override fun startCall(store: Store<ReduxState>) {

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/CallingService.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/CallingService.kt
@@ -103,7 +103,7 @@ internal class CallingService(
         return callingSdk.resume()
     }
 
-    fun setupCall(): CompletableFuture<DeviceManager> {
+    fun setupCall(): CompletableFuture<Void> {
         return callingSdk.setupCall()
     }
 

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/CallingService.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/CallingService.kt
@@ -3,7 +3,6 @@
 
 package com.azure.android.communication.ui.calling.service
 
-import com.azure.android.communication.calling.DeviceManager
 import com.azure.android.communication.ui.calling.logger.Logger
 import com.azure.android.communication.ui.calling.models.CallInfoModel
 import com.azure.android.communication.ui.calling.models.ParticipantInfoModel

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/CallingService.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/CallingService.kt
@@ -3,6 +3,7 @@
 
 package com.azure.android.communication.ui.calling.service
 
+import com.azure.android.communication.calling.DeviceManager
 import com.azure.android.communication.ui.calling.logger.Logger
 import com.azure.android.communication.ui.calling.models.CallInfoModel
 import com.azure.android.communication.ui.calling.models.ParticipantInfoModel
@@ -102,8 +103,8 @@ internal class CallingService(
         return callingSdk.resume()
     }
 
-    fun setupCall() {
-        callingSdk.setupCall()
+    fun setupCall(): CompletableFuture<DeviceManager> {
+        return callingSdk.setupCall()
     }
 
     fun dispose() {

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDK.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDK.kt
@@ -4,17 +4,17 @@
 package com.azure.android.communication.ui.calling.service.sdk
 
 import android.view.View
-import com.azure.android.communication.calling.CameraFacing
-import com.azure.android.communication.calling.CreateViewOptions
-import com.azure.android.communication.calling.MediaStreamType
-import com.azure.android.communication.calling.ParticipantState
-import com.azure.android.communication.calling.PropertyChangedListener
-import com.azure.android.communication.calling.RemoteVideoStreamsUpdatedListener
-import com.azure.android.communication.calling.VideoDeviceType
+import com.azure.android.communication.calling.*
 import com.azure.android.communication.ui.calling.models.ParticipantInfoModel
 import com.azure.android.communication.ui.calling.redux.state.AudioState
 import com.azure.android.communication.ui.calling.redux.state.CameraDeviceSelectionStatus
 import com.azure.android.communication.ui.calling.redux.state.CameraState
+import com.azure.android.communication.ui.calling.service.sdk.LocalVideoStream
+import com.azure.android.communication.ui.calling.service.sdk.RemoteParticipant
+import com.azure.android.communication.ui.calling.service.sdk.RemoteVideoStream
+import com.azure.android.communication.ui.calling.service.sdk.StreamSize
+import com.azure.android.communication.ui.calling.service.sdk.VideoDeviceInfo
+import com.azure.android.communication.ui.calling.service.sdk.VideoStreamRendererView
 import java9.util.concurrent.CompletableFuture
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.SharedFlow
  */
 internal interface CallingSDK {
     // Internal helpers. Refactor these out further.
-    fun setupCall()
+    fun setupCall(): CompletableFuture<DeviceManager>
     fun dispose()
 
     // Interactions.

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDK.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDK.kt
@@ -4,17 +4,18 @@
 package com.azure.android.communication.ui.calling.service.sdk
 
 import android.view.View
-import com.azure.android.communication.calling.*
+import com.azure.android.communication.calling.DeviceManager
+import com.azure.android.communication.calling.ParticipantState
+import com.azure.android.communication.calling.PropertyChangedListener
+import com.azure.android.communication.calling.RemoteVideoStreamsUpdatedListener
+import com.azure.android.communication.calling.MediaStreamType
+import com.azure.android.communication.calling.CameraFacing
+import com.azure.android.communication.calling.VideoDeviceType
+import com.azure.android.communication.calling.CreateViewOptions
 import com.azure.android.communication.ui.calling.models.ParticipantInfoModel
 import com.azure.android.communication.ui.calling.redux.state.AudioState
 import com.azure.android.communication.ui.calling.redux.state.CameraDeviceSelectionStatus
 import com.azure.android.communication.ui.calling.redux.state.CameraState
-import com.azure.android.communication.ui.calling.service.sdk.LocalVideoStream
-import com.azure.android.communication.ui.calling.service.sdk.RemoteParticipant
-import com.azure.android.communication.ui.calling.service.sdk.RemoteVideoStream
-import com.azure.android.communication.ui.calling.service.sdk.StreamSize
-import com.azure.android.communication.ui.calling.service.sdk.VideoDeviceInfo
-import com.azure.android.communication.ui.calling.service.sdk.VideoStreamRendererView
 import java9.util.concurrent.CompletableFuture
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDK.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDK.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.SharedFlow
  */
 internal interface CallingSDK {
     // Internal helpers. Refactor these out further.
-    fun setupCall(): CompletableFuture<DeviceManager>
+    fun setupCall(): CompletableFuture<Void>
     fun dispose()
 
     // Interactions.

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDK.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDK.kt
@@ -4,7 +4,6 @@
 package com.azure.android.communication.ui.calling.service.sdk
 
 import android.view.View
-import com.azure.android.communication.calling.DeviceManager
 import com.azure.android.communication.calling.ParticipantState
 import com.azure.android.communication.calling.PropertyChangedListener
 import com.azure.android.communication.calling.RemoteVideoStreamsUpdatedListener

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDKWrapper.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDKWrapper.kt
@@ -4,7 +4,6 @@
 package com.azure.android.communication.ui.calling.service.sdk
 
 import android.content.Context
-import android.util.Log
 import com.azure.android.communication.calling.AudioOptions
 import com.azure.android.communication.calling.Call
 import com.azure.android.communication.calling.CallAgent
@@ -365,7 +364,6 @@ internal class CallingSDKWrapper(
                         deviceManagerCompletableFuture.completeExceptionally(
                             getDeviceManagerError
                         )
-
                     } else {
                         deviceManagerCompletableFuture.complete(deviceManager)
                     }

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDKWrapper.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDKWrapper.kt
@@ -23,11 +23,8 @@ import com.azure.android.communication.calling.VideoOptions
 import com.azure.android.communication.ui.calling.configuration.CallCompositeConfiguration
 import com.azure.android.communication.ui.calling.configuration.CallConfiguration
 import com.azure.android.communication.ui.calling.configuration.CallType
-import com.azure.android.communication.ui.calling.error.ErrorCode
-import com.azure.android.communication.ui.calling.error.FatalError
 import com.azure.android.communication.ui.calling.logger.Logger
 import com.azure.android.communication.ui.calling.models.ParticipantInfoModel
-import com.azure.android.communication.ui.calling.redux.action.ErrorAction
 import com.azure.android.communication.ui.calling.redux.state.AudioOperationalStatus
 import com.azure.android.communication.ui.calling.redux.state.AudioState
 import com.azure.android.communication.ui.calling.redux.state.CameraDeviceSelectionStatus

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDKWrapper.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDKWrapper.kt
@@ -4,6 +4,7 @@
 package com.azure.android.communication.ui.calling.service.sdk
 
 import android.content.Context
+import android.util.Log
 import com.azure.android.communication.calling.AudioOptions
 import com.azure.android.communication.calling.Call
 import com.azure.android.communication.calling.CallAgent
@@ -130,20 +131,21 @@ internal class CallingSDKWrapper(
         cleanupResources()
     }
 
-    override fun setupCall() {
+    override fun setupCall(): CompletableFuture<DeviceManager> {
         if (callClient == null) {
             val callClientOptions = CallClientOptions().also {
                 it.setTags(configuration.callConfig?.diagnosticConfig?.tags, logger)
             }
             callClient = CallClient(callClientOptions)
         }
-        createDeviceManager()
+        return createDeviceManager()
     }
 
     override fun startCall(
         cameraState: CameraState,
         audioState: AudioState,
     ): CompletableFuture<Void> {
+
         val startCallCompletableFuture = CompletableFuture<Void>()
         createCallAgent().thenAccept { agent: CallAgent ->
             val audioOptions = AudioOptions()
@@ -351,7 +353,7 @@ internal class CallingSDKWrapper(
         return deviceManagerCompletableFuture!!
     }
 
-    private fun createDeviceManager() {
+    private fun createDeviceManager(): CompletableFuture<DeviceManager> {
         val deviceManagerCompletableFuture = getDeviceManagerCompletableFuture()
 
         if (deviceManagerCompletableFuture.isCompletedExceptionally ||
@@ -363,6 +365,7 @@ internal class CallingSDKWrapper(
                         deviceManagerCompletableFuture.completeExceptionally(
                             getDeviceManagerError
                         )
+
                     } else {
                         deviceManagerCompletableFuture.complete(deviceManager)
                     }
@@ -372,6 +375,7 @@ internal class CallingSDKWrapper(
         CompletableFuture.allOf(
             deviceManagerCompletableFuture,
         )
+        return deviceManagerCompletableFuture
     }
 
     private fun initializeCameras(): CompletableFuture<Void> {

--- a/azure-communication-ui/azure-communication-ui/src/testCalling/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandlerUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/testCalling/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandlerUnitTest.kt
@@ -495,7 +495,6 @@ internal class CallingMiddlewareActionHandlerUnitTest : ACSBaseTestCoroutine() {
 
             val mockAppStore = mock<AppStore<ReduxState>> {
                 on { dispatch(any()) } doAnswer { }
-                on { getCurrentState() } doAnswer { appState }
             }
 
             val exception = Exception("test")
@@ -1770,7 +1769,6 @@ internal class CallingMiddlewareActionHandlerUnitTest : ACSBaseTestCoroutine() {
 
             // act
             handler.startCall(mockAppStore)
-            handler.setupCall(mockAppStore)
             callInfoModelStateFlow.emit(CallInfoModel(CallingStatus.DISCONNECTED, null))
 
             // assert
@@ -1837,7 +1835,6 @@ internal class CallingMiddlewareActionHandlerUnitTest : ACSBaseTestCoroutine() {
 
             // act
             handler.startCall(mockAppStore)
-            handler.setupCall(mockAppStore)
             callInfoModelStateFlow.emit(
                 CallInfoModel(
                     CallingStatus.DISCONNECTED,
@@ -1848,12 +1845,6 @@ internal class CallingMiddlewareActionHandlerUnitTest : ACSBaseTestCoroutine() {
             )
 
             // assert
-            verify(mockAppStore, times(0)).dispatch(
-                argThat { action ->
-                    action is ErrorAction.FatalErrorOccurred &&
-                        action.error.errorCode == UNKNOWN_ERROR
-                }
-            )
             verify(mockAppStore, times(0)).dispatch(
                 argThat { action ->
                     action is ErrorAction.CallStateErrorOccurred &&

--- a/azure-communication-ui/azure-communication-ui/src/testCalling/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandlerUnitTest.kt
+++ b/azure-communication-ui/azure-communication-ui/src/testCalling/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandlerUnitTest.kt
@@ -485,7 +485,7 @@ internal class CallingMiddlewareActionHandlerUnitTest : ACSBaseTestCoroutine() {
 
             val setupCallCompletableFuture: CompletableFuture<Void> = CompletableFuture()
             val mockCallingService: CallingService = mock {
-                on {setupCall()} doReturn setupCallCompletableFuture
+                on { setupCall() } doReturn setupCallCompletableFuture
             }
 
             val handler = CallingMiddlewareActionHandlerImpl(
@@ -506,10 +506,9 @@ internal class CallingMiddlewareActionHandlerUnitTest : ACSBaseTestCoroutine() {
             verify(mockAppStore, times(1)).dispatch(
                 argThat { action ->
                     action is ErrorAction.FatalErrorOccurred &&
-                            action.error.fatalError == exception && action.error.errorCode == ErrorCode.UNKNOWN_ERROR
+                        action.error.fatalError == exception && action.error.errorCode == ErrorCode.UNKNOWN_ERROR
                 }
             )
-
         }
 
     @ExperimentalCoroutinesApi
@@ -1852,7 +1851,7 @@ internal class CallingMiddlewareActionHandlerUnitTest : ACSBaseTestCoroutine() {
             verify(mockAppStore, times(0)).dispatch(
                 argThat { action ->
                     action is ErrorAction.FatalErrorOccurred &&
-                            action.error.errorCode == UNKNOWN_ERROR
+                        action.error.errorCode == UNKNOWN_ERROR
                 }
             )
             verify(mockAppStore, times(0)).dispatch(


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Adding unknown error state for ambiguous error state
* Adding error state propagation for device manager error

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [x] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [x] Public API changes
- [ ] Verified for cross-platform
- [x] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [x] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [x] Tested for background mode
  - [x] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open CallingMiddlewareActionHandlerUnitTest class on test package
* run the test for function "callingMiddlewareActionHandler_setupCall_fails_then_dispatchFatalError"


## What to Check
Verify that the following are valid
* Verify that the test is passed or not

## Other Information
<!-- Add any other helpful information that may be needed here. -->
* User story: [User Story 2630120](https://skype.visualstudio.com/SPOOL/_workitems/edit/2630120): [Android] As a Developer I want to receive error event when device manager throws any error
