### PR TITLE
[Feature] Dispatch cameraFailure error to subscribers

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorHandler.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorHandler.kt
@@ -6,7 +6,10 @@ package com.azure.android.communication.ui.calling.error
 import com.azure.android.communication.ui.calling.configuration.CallCompositeConfiguration
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.CALL_END_FAILED
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.CALL_JOIN_FAILED
+import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.SWITCH_CAMERA_FAILED
 import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TOKEN_EXPIRED
+import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TURN_CAMERA_OFF_FAILED
+import com.azure.android.communication.ui.calling.error.ErrorCode.Companion.TURN_CAMERA_ON_FAILED
 import com.azure.android.communication.ui.calling.models.CallCompositeErrorCode
 import com.azure.android.communication.ui.calling.models.CallCompositeErrorEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeEventCode
@@ -120,6 +123,9 @@ internal class ErrorHandler(
                 }
                 CALL_END_FAILED -> {
                     return CallCompositeErrorCode.CALL_END_FAILED
+                }
+                SWITCH_CAMERA_FAILED, TURN_CAMERA_ON_FAILED, TURN_CAMERA_OFF_FAILED -> {
+                    return CallCompositeErrorCode.CAMERA_FAILURE
                 }
                 else -> {
                     return null

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeErrorCode.java
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeErrorCode.java
@@ -27,6 +27,12 @@ public final class CallCompositeErrorCode extends ExpandableStringEnum<CallCompo
      */
     public static final CallCompositeErrorCode TOKEN_EXPIRED = fromString("tokenExpired");
 
+
+    /**
+     * Dispatched when camera failed to start, stop or switch
+     */
+    public static final CallCompositeErrorCode CAMERA_FAILURE = fromString("cameraFailure");
+
     /**
      * Creates or finds a {@link CallCompositeErrorCode} from its string representation.
      *
@@ -43,5 +49,6 @@ public final class CallCompositeErrorCode extends ExpandableStringEnum<CallCompo
     public static Collection<CallCompositeErrorCode> values() {
         return values(CallCompositeErrorCode.class);
     }
+
 }
 

--- a/docs/CHANGELOG_UI_CALLING.md
+++ b/docs/CHANGELOG_UI_CALLING.md
@@ -2,6 +2,7 @@
 
 ### Features
 - Setting up Group Call Title and Subtitle is now possible by customizing CallCompositeLocalOptions with CallCompositeNavigationBarViewData
+- Implemented new error message `cameraFailure` that can be sent to developers when turning on camera fails.
 
 ### Bug Fixes
 - Display DrawerDialog across screen rotation


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Dispatch camera start / stop / switch errors to subscribers

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [x] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [x] Public API changes
- [ ] Verified for cross-platform
- [x] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Setup an error event handler for call composite
* Setup calls and do something which causes any camera error to occur


## What to Check
Verify that the following are valid
* Error `cameraFailure` is dispatched to the event handler
