### PR TITLE
[Feature] Open OS settings permission menu via shortcut button

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorHandler.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/error/ErrorHandler.kt
@@ -136,7 +136,6 @@ internal class ErrorHandler(
                 }
             }
         }
-
         return null
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/PermissionWarningView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/PermissionWarningView.kt
@@ -4,8 +4,12 @@
 package com.azure.android.communication.ui.calling.presentation.fragment.setup.components
 
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
 import android.util.AttributeSet
 import android.view.View
+import android.widget.Button
 import android.widget.ImageView
 import android.widget.LinearLayout
 import androidx.appcompat.widget.AppCompatTextView
@@ -27,6 +31,7 @@ internal class PermissionWarningView : LinearLayout {
     private lateinit var setupPermissionsHolder: LinearLayout
     private lateinit var setupMissingImage: ImageView
     private lateinit var setupMissingText: AppCompatTextView
+    private lateinit var setupSettingsButton: Button
 
     override fun onFinishInflate() {
         super.onFinishInflate()
@@ -36,6 +41,12 @@ internal class PermissionWarningView : LinearLayout {
             findViewById(R.id.azure_communication_ui_setup_missing_image)
         setupMissingText =
             findViewById(R.id.azure_communication_ui_setup_missing_text)
+        setupSettingsButton =
+            findViewById(R.id.azure_communication_ui_setup_settings_button)
+
+        setupSettingsButton.setOnClickListener {
+            openSettings()
+        }
     }
 
     fun start(
@@ -97,5 +108,13 @@ internal class PermissionWarningView : LinearLayout {
             )
             setupMissingText.setText(context.getString(R.string.azure_communication_ui_calling_setup_view_preview_area_camera_disabled))
         }
+    }
+
+    private fun openSettings() {
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val uri = Uri.fromParts("package", context.packageName, null)
+        intent.data = uri
+        context.startActivity(intent)
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_fragment_setup.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_fragment_setup.xml
@@ -102,6 +102,15 @@
                 android:text="@string/azure_communication_ui_calling_setup_view_warning_missing_text"
                 android:textColor="@color/azure_communication_ui_calling_color_on_surface"
                 />
+
+            <Button
+                android:id="@+id/azure_communication_ui_setup_settings_button"
+                android:layout_width="142dp"
+                android:layout_height="48dp"
+                android:background="@drawable/button_outlined"
+                android:text="@string/azure_communication_ui_calling_setup_view_go_to_settingst" />
+
+
         </com.azure.android.communication.ui.calling.presentation.fragment.setup.components.PermissionWarningView>
 
         <com.azure.android.communication.ui.calling.presentation.fragment.setup.components.SetupControlBarView

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_fragment_setup.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/layout/azure_communication_ui_calling_fragment_setup.xml
@@ -103,10 +103,11 @@
                 android:textColor="@color/azure_communication_ui_calling_color_on_surface"
                 />
 
-            <Button
+            <com.microsoft.fluentui.widget.Button
                 android:id="@+id/azure_communication_ui_setup_settings_button"
                 android:layout_width="142dp"
                 android:layout_height="48dp"
+                android:textColor="@color/azure_communication_ui_calling_color_primary"
                 android:background="@drawable/button_outlined"
                 android:text="@string/azure_communication_ui_calling_setup_view_go_to_settingst" />
 

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-de-rDE/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-de-rDE/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Ihre Kamera ist deaktiviert. Wechseln Sie zum Aktivieren zu „Einstellungen“
 ,         um den Zugriff zuzulassen.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Berechtigungen erforderlich</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Ausgewählt</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Farbverlauf einrichten</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Kamera wechseln</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-de/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-de/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Ihre Kamera ist deaktiviert. Wechseln Sie zum Aktivieren zu „Einstellungen“
 ,         um den Zugriff zuzulassen.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Berechtigungen erforderlich</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Ausgewählt</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Farbverlauf einrichten</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Kamera wechseln</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-en-rGB/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-en-rGB/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Your camera is disabled. To enable, please go to Settings
         to allow access.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Permissions required</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Selected</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Setup Gradient</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Switch Camera</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-es-rES/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-es-rES/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Su cámara está deshabilitada. Para habilitarla, vaya a Configuración
         para permitir el acceso.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Permisos necesarios</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Seleccionado</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Configuración de degradado</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Cambiar de cámara</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-es/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-es/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Su cámara está deshabilitada. Para habilitarla, vaya a Configuración
         para permitir el acceso.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Permisos necesarios</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Seleccionado</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Configuración de degradado</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Cambiar de cámara</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-fr-rFR/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-fr-rFR/azure_communication_ui_calling_strings.xml
@@ -13,7 +13,7 @@
     <string name="azure_communication_ui_calling_setup_audio_device_select_content_description">Sélectionner le périphérique audio %1$s</string>
     <string name="azure_communication_ui_calling_selected_audio_device_announcement">Périphérique audio %1$s, sélectionné</string>
     <!--    Setup View-->
-    <string name="azure_communication_ui_calling_setup_view_button_connecting_call">Connexion à l\'appel en cours…</string>
+    <string name="azure_communication_ui_calling_setup_view_button_connecting_call">Connexion à l\'appel en cours… Merci de patienter.</string>
     <string name="azure_communication_ui_calling_setup_view_button_video_off">Vidéo désactivée</string>
     <string name="azure_communication_ui_calling_setup_view_button_video_on">Vidéo activée</string>
     <string name="azure_communication_ui_calling_setup_view_button_mic_off">Microphone désactivé</string>
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Votre caméra est désactivée. Pour l’activer, accédez à Paramètres
         pour autoriser l’accès.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Autorisations requises</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Sélectionné</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Configurer le dégradé</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Changer de caméra</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-fr/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-fr/azure_communication_ui_calling_strings.xml
@@ -13,7 +13,7 @@
     <string name="azure_communication_ui_calling_setup_audio_device_select_content_description">Sélectionner le périphérique audio %1$s</string>
     <string name="azure_communication_ui_calling_selected_audio_device_announcement">Périphérique audio %1$s, sélectionné</string>
     <!--    Setup View-->
-    <string name="azure_communication_ui_calling_setup_view_button_connecting_call">Connexion à l\'appel en cours…</string>
+    <string name="azure_communication_ui_calling_setup_view_button_connecting_call">Connexion à l\'appel en cours… Merci de patienter.</string>
     <string name="azure_communication_ui_calling_setup_view_button_video_off">Vidéo désactivée</string>
     <string name="azure_communication_ui_calling_setup_view_button_video_on">Vidéo activée</string>
     <string name="azure_communication_ui_calling_setup_view_button_mic_off">Microphone désactivé</string>
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Votre caméra est désactivée. Pour l’activer, accédez à Paramètres
         pour autoriser l’accès.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Autorisations requises</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Sélectionné</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Configurer le dégradé</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Changer de caméra</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-it-rIT/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-it-rIT/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">La fotocamera è disabilitata. Per abilitarla, passare a Impostazioni
         per consentire l\'accesso.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Autorizzazioni necessarie</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Selezionato</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Imposta sfumatura</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Gira fotocamera</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-it/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-it/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">La fotocamera è disabilitata. Per abilitarla, passare a Impostazioni
         per consentire l\'accesso.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Autorizzazioni necessarie</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Selezionato</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Imposta sfumatura</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Gira fotocamera</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-ja-rJP/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-ja-rJP/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">カメラが無効になっています。有効にするには、[設定] に移動して
         アクセスを許可してください。</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">アクセス許可が必要です</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">選択済み</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">グラデーションの設定</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">カメラの切り替え</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-ja/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-ja/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">カメラが無効になっています。有効にするには、[設定] に移動して
         アクセスを許可してください。</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">アクセス許可が必要です</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">選択済み</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">グラデーションの設定</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">カメラの切り替え</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-ko-rKR/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-ko-rKR/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">카메라를 사용하지 않도록 설정했습니다. 사용하도록 설정하려면 설정으로
         이동하여 액세스를 허용하세요.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">권한 필요</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">선택함</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">설정 그라데이션</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">카메라 전환</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-ko/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-ko/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">카메라를 사용하지 않도록 설정했습니다. 사용하도록 설정하려면 설정으로
         이동하여 액세스를 허용하세요.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">권한 필요</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">선택함</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">설정 그라데이션</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">카메라 전환</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-nl-rNL/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-nl-rNL/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Uw camera is uitgeschakeld. Als u deze wilt inschakelen, gaat u naar Instellingen
         om toegang toe te staan.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Machtigingen vereist</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Geselecteerd</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Kleurovergang instellen</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Camera wisselen</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-nl/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-nl/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Uw camera is uitgeschakeld. Als u deze wilt inschakelen, gaat u naar Instellingen
         om toegang toe te staan.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Machtigingen vereist</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Geselecteerd</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Kleurovergang instellen</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Camera wisselen</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-pt-rBR/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-pt-rBR/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Sua câmera está desabilitada. Para habilitar, vá para Configurações
  para permitir o acesso.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Permissões necessárias</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Selecionado</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Configurar Gradiente</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Alternar Câmera</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-pt/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-pt/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Sua câmera está desabilitada. Para habilitar, vá para Configurações
  para permitir o acesso.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Permissões necessárias</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Selecionado</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Configurar Gradiente</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Alternar Câmera</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-ru-rRU/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-ru-rRU/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Камера отключена. Для включения перейдите в раздел "Параметры",
         чтобы разрешить доступ.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Требуются разрешения</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Выбрано</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Настройка градиента</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Переключение на другую камеру</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-ru/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-ru/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Камера отключена. Для включения перейдите в раздел "Параметры",
         чтобы разрешить доступ.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Требуются разрешения</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Выбрано</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Настройка градиента</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Переключение на другую камеру</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-tr-rTR/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-tr-rTR/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Kameranız devre dışı. Etkinleştirmek için Ayarlar seçeneğine giderek
       erişime izin verin.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">İzinler gerekli</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Seçili</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Gradyan Kur</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Kamerayı Değiştir</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-tr/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-tr/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Kameranız devre dışı. Etkinleştirmek için Ayarlar seçeneğine giderek
       erişime izin verin.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">İzinler gerekli</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Seçili</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Gradyan Kur</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Kamerayı Değiştir</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-zh-rCN/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-zh-rCN/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">你的相机已禁用。若要启用，请转到“设置”
 以允许访问。</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">需要权限</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">已选择</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">设置渐变</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">切换摄像头</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-zh-rTW/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-zh-rTW/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">您的相機已停用。若要啟用，請移至 [設定]
         以允許存取。</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">需要權限</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">已選取</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">設定漸層</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">切換相機</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values-zh/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values-zh/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">你的相机已禁用。若要启用，请转到“设置”
 以允许访问。</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">需要权限</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">已选择</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">设置渐变</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">切换摄像头</string>

--- a/azure-communication-ui/azure-communication-ui/src/calling/res/values/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/azure-communication-ui/src/calling/res/values/azure_communication_ui_calling_strings.xml
@@ -24,6 +24,7 @@
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Your camera is disabled. To enable, please go to Settings
         to allow access.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Permissions required</string>
+    <string name="azure_communication_ui_calling_setup_view_go_to_settingst">Go to Settings</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Selected</string>
     <string name="azure_communication_ui_calling_setup_view_background_gradient_accessibility_label">Setup Gradient</string>
     <string name="azure_communication_ui_calling_button_switch_camera_accessibility_label">Switch Camera</string>

--- a/docs/CHANGELOG_UI_CALLING.md
+++ b/docs/CHANGELOG_UI_CALLING.md
@@ -3,6 +3,7 @@
 ### Features
 - Setting up Group Call Title and Subtitle is now possible by customizing CallCompositeLocalOptions with CallCompositeNavigationBarViewData
 - Implemented new error message `cameraFailure` that can be sent to developers when turning on camera fails.
+- Added new button to allow user to quickly navigate to app's info page when permissions are denied.
 
 ### Bug Fixes
 - Display DrawerDialog across screen rotation


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Allows user to open app's settings info page when permissions are denied for easy access.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
