### PR TITLE
refactor: Converted CallCompositeNavigationBarViewData to use Fluent construction

### DIFF
--- a/azure-communication-ui/azure-communication-ui-demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/launcher/CallingCompositeJavaLauncher.java
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/launcher/CallingCompositeJavaLauncher.java
@@ -82,8 +82,11 @@ public class CallingCompositeJavaLauncher implements CallingCompositeLauncher {
 
 
         final CallCompositeLocalOptions localOptions = new CallCompositeLocalOptions(participantViewData);
-        localOptions.setNavigationBarViewData(new CallCompositeNavigationBarViewData(SettingsFeatures.getCallTitle(),
-                SettingsFeatures.getCallSubTitle()));
+
+        localOptions.setNavigationBarViewData(new CallCompositeNavigationBarViewData()
+                .setCallTitle(SettingsFeatures.getCallTitle())
+                .setCallSubTitle(SettingsFeatures.getCallSubTitle())
+        );
 
         callComposite.launch(callLauncherActivity, remoteOptions, localOptions);
     }

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/launcher/CallingCompositeJavaLauncher.java
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/launcher/CallingCompositeJavaLauncher.java
@@ -9,6 +9,8 @@ import com.azure.android.communication.ui.calling.CallComposite;
 import com.azure.android.communication.ui.calling.CallCompositeBuilder;
 import com.azure.android.communication.ui.calling.models.CallCompositeGroupCallLocator;
 import com.azure.android.communication.ui.calling.models.CallCompositeJoinLocator;
+import com.azure.android.communication.ui.calling.models.CallCompositeLocalOptions;
+import com.azure.android.communication.ui.calling.models.CallCompositeLocalizationOptions;
 import com.azure.android.communication.ui.calling.models.CallCompositeNavigationBarViewData;
 import com.azure.android.communication.ui.calling.models.CallCompositeRemoteOptions;
 import com.azure.android.communication.ui.calling.models.CallCompositeTeamsMeetingLinkLocator;
@@ -18,9 +20,6 @@ import com.azure.android.communication.ui.callingcompositedemoapp.R;
 import com.azure.android.communication.ui.callingcompositedemoapp.RemoteParticipantJoinedHandler;
 import com.azure.android.communication.ui.callingcompositedemoapp.features.AdditionalFeatures;
 import com.azure.android.communication.ui.callingcompositedemoapp.features.SettingsFeatures;
-import com.azure.android.communication.ui.calling.models.CallCompositeLocalOptions;
-import com.azure.android.communication.ui.calling.models.CallCompositeLocalizationOptions;
-import com.azure.android.communication.ui.calling.models.CallCompositeParticipantViewData;
 
 import java.util.Locale;
 import java.util.UUID;
@@ -46,9 +45,6 @@ public class CallingCompositeJavaLauncher implements CallingCompositeLauncher {
         final CallCompositeBuilder builder = new CallCompositeBuilder();
 
         SettingsFeatures.initialize(callLauncherActivity.getApplicationContext());
-
-        final CallCompositeParticipantViewData participantViewData =
-                SettingsFeatures.getParticipantViewData(callLauncherActivity.getApplicationContext());
 
         final String selectedLanguage = SettingsFeatures.language();
         final Locale locale = SettingsFeatures.locale(selectedLanguage);
@@ -81,12 +77,12 @@ public class CallingCompositeJavaLauncher implements CallingCompositeLauncher {
                 new CallCompositeRemoteOptions(locator, communicationTokenCredential, displayName);
 
 
-        final CallCompositeLocalOptions localOptions = new CallCompositeLocalOptions(participantViewData);
-
-        localOptions.setNavigationBarViewData(new CallCompositeNavigationBarViewData()
-                .setCallTitle(SettingsFeatures.getCallTitle())
-                .setCallSubTitle(SettingsFeatures.getCallSubTitle())
-        );
+        final CallCompositeLocalOptions localOptions = new CallCompositeLocalOptions()
+                .setParticipantViewData(SettingsFeatures
+                        .getParticipantViewData(callLauncherActivity.getApplicationContext()))
+                .setNavigationBarViewData(new CallCompositeNavigationBarViewData()
+                    .setCallTitle(SettingsFeatures.getCallTitle())
+                    .setCallSubTitle(SettingsFeatures.getCallSubTitle()));
 
         callComposite.launch(callLauncherActivity, remoteOptions, localOptions);
     }

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/launcher/CallingCompositeKotlinLauncher.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/launcher/CallingCompositeKotlinLauncher.kt
@@ -75,10 +75,9 @@ class CallingCompositeKotlinLauncher(private val tokenRefresher: Callable<String
         val remoteOptions = CallCompositeRemoteOptions(locator, communicationTokenCredential, displayName)
 
         val localOptions = CallCompositeLocalOptions(participantViewData)
-        localOptions.navigationBarViewData = CallCompositeNavigationBarViewData(
-            getCallTitle(),
-            getCallSubTitle()
-        )
+        localOptions.navigationBarViewData = CallCompositeNavigationBarViewData()
+            .setCallTitle(getCallTitle())
+            .setCallSubTitle(getCallSubTitle())
 
         callComposite.launch(callLauncherActivity, remoteOptions, localOptions)
     }

--- a/azure-communication-ui/azure-communication-ui-demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/launcher/CallingCompositeKotlinLauncher.kt
+++ b/azure-communication-ui/azure-communication-ui-demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/launcher/CallingCompositeKotlinLauncher.kt
@@ -41,7 +41,6 @@ class CallingCompositeKotlinLauncher(private val tokenRefresher: Callable<String
         showAlert: ((String) -> Unit)?,
     ) {
         initialize(callLauncherActivity.applicationContext)
-        val participantViewData = getParticipantViewData(callLauncherActivity.applicationContext)
         val selectedLanguage = language()
         val locale = selectedLanguage?.let { locale(it) }
 
@@ -74,10 +73,13 @@ class CallingCompositeKotlinLauncher(private val tokenRefresher: Callable<String
 
         val remoteOptions = CallCompositeRemoteOptions(locator, communicationTokenCredential, displayName)
 
-        val localOptions = CallCompositeLocalOptions(participantViewData)
-        localOptions.navigationBarViewData = CallCompositeNavigationBarViewData()
-            .setCallTitle(getCallTitle())
-            .setCallSubTitle(getCallSubTitle())
+        val localOptions = CallCompositeLocalOptions()
+            .setParticipantViewData(getParticipantViewData(callLauncherActivity.applicationContext))
+            .setNavigationBarViewData(
+                CallCompositeNavigationBarViewData()
+                    .setCallTitle(getCallTitle())
+                    .setCallSubTitle(getCallSubTitle())
+            )
 
         callComposite.launch(callLauncherActivity, remoteOptions, localOptions)
     }

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeLocalOptions.java
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeLocalOptions.java
@@ -62,10 +62,13 @@ public final class CallCompositeLocalOptions {
 
     /**
      * Set a {@link CallCompositeParticipantViewData} to be used
-     * @param participantViewData
+     * @param participantViewData The participant view data object to be used
+     * @return The current CallCompositeLocalOptions object for Fluent use
      */
-    public void setParticipantViewData(final CallCompositeParticipantViewData participantViewData) {
+    public CallCompositeLocalOptions setParticipantViewData(
+            final CallCompositeParticipantViewData participantViewData) {
         this.participantViewData = participantViewData;
+        return this;
     }
 
     /**
@@ -78,9 +81,12 @@ public final class CallCompositeLocalOptions {
 
     /**
      * Set a {@link CallCompositeNavigationBarViewData} to be used
-     * @param navigationBarViewData The CallCompositeNavigationBarViewData that is currently set
+     * @param navigationBarViewData The navigationbar view data object to be used
+     * @return The current CallCompositeLocalOptions object for Fluent use
      */
-    public void setNavigationBarViewData(final CallCompositeNavigationBarViewData navigationBarViewData) {
+    public CallCompositeLocalOptions setNavigationBarViewData(
+            final CallCompositeNavigationBarViewData navigationBarViewData) {
         this.navigationBarViewData = navigationBarViewData;
+        return this;
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeLocalOptions.java
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeLocalOptions.java
@@ -3,8 +3,6 @@
 
 package com.azure.android.communication.ui.calling.models;
 
-import androidx.annotation.Nullable;
-
 import com.azure.android.communication.ui.calling.CallComposite;
 
 /**
@@ -33,10 +31,8 @@ import com.azure.android.communication.ui.calling.CallComposite;
  * @see CallComposite
  */
 public final class CallCompositeLocalOptions {
-    @Nullable
     private CallCompositeParticipantViewData participantViewData = null;
 
-    @Nullable
     private CallCompositeNavigationBarViewData navigationBarViewData = null;
 
 
@@ -58,9 +54,8 @@ public final class CallCompositeLocalOptions {
     /**
      * Get the {@link CallCompositeParticipantViewData}
      *
-     * @return The {@link CallCompositeParticipantViewData};
+     * @return The {@link CallCompositeParticipantViewData} that is currently set
      */
-    @Nullable
     public CallCompositeParticipantViewData getParticipantViewData() {
         return participantViewData;
     }
@@ -69,24 +64,23 @@ public final class CallCompositeLocalOptions {
      * Set a {@link CallCompositeParticipantViewData} to be used
      * @param participantViewData
      */
-    public void setParticipantViewData(@Nullable final CallCompositeParticipantViewData participantViewData) {
+    public void setParticipantViewData(final CallCompositeParticipantViewData participantViewData) {
         this.participantViewData = participantViewData;
     }
 
     /**
      * Get the {@link CallCompositeNavigationBarViewData}
-     * @return
+     * @return The CallCompositeNavigationBarViewData that is currently set
      */
-    @Nullable
     public CallCompositeNavigationBarViewData getNavigationBarViewData() {
         return navigationBarViewData;
     }
 
     /**
      * Set a {@link CallCompositeNavigationBarViewData} to be used
-     * @param navigationBarViewData
+     * @param navigationBarViewData The CallCompositeNavigationBarViewData that is currently set
      */
-    public void setNavigationBarViewData(@Nullable final CallCompositeNavigationBarViewData navigationBarViewData) {
+    public void setNavigationBarViewData(final CallCompositeNavigationBarViewData navigationBarViewData) {
         this.navigationBarViewData = navigationBarViewData;
     }
 }

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeNavigationBarViewData.java
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/models/CallCompositeNavigationBarViewData.java
@@ -3,8 +3,6 @@
 
 package com.azure.android.communication.ui.calling.models;
 
-import androidx.annotation.Nullable;
-
 /**
  * Provides navigation bar view data to Call Composite including title and subTitle
  *
@@ -13,38 +11,48 @@ import androidx.annotation.Nullable;
  *
  */
 public final class CallCompositeNavigationBarViewData {
-    @Nullable
-    private final String callTitle;
+    private String callTitle = null;
 
-    @Nullable
-    private final String callSubTitle;
+    private String callSubTitle = null;
 
     /**
-     * Constructs a {@link  CallCompositeNavigationBarViewData}
-     * @param callTitle Default title "Setup" is used if not customized
-     * @param callSubTitle Will appear as a 2nd line under callTitle. Will *not* appear unless
-     *                     callTitle is also specified
+     * Constructs an empty {@link  CallCompositeNavigationBarViewData}
      */
-    public CallCompositeNavigationBarViewData(@Nullable final String callTitle, @Nullable final String callSubTitle) {
-        this.callTitle = callTitle;
-        this.callSubTitle = callSubTitle;
-    }
+    public CallCompositeNavigationBarViewData() { }
 
     /**
      * Get the call title
-     * @return
+     * @return The title of the call
      */
-    @Nullable
     public String getCallTitle() {
         return callTitle;
     }
 
     /**
      * Get the call sub title
-     * @return
+     * @return The subtitle of the call
      */
-    @Nullable
     public String getCallSubTitle() {
         return callSubTitle;
+    }
+
+    /**
+     * Set the title of the call setup screen to the supplied String
+     * @param callTitle Title of the call
+     * @return The current CallCompositeNavigationBarViewData for Fluent use
+     */
+    public CallCompositeNavigationBarViewData setCallTitle(final String callTitle) {
+        this.callTitle = callTitle;
+        return this;
+    }
+
+    /**
+     * Set the subtitle of the call setup screen to the supplied String
+     * @param callSubTitle Subtitle of the call
+     * @return The current CallCompositeNavigationBarViewData for Fluent use
+     */
+    public CallCompositeNavigationBarViewData setCallSubTitle(final String callSubTitle) {
+        this.callSubTitle = callSubTitle;
+        return this;
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* CallCompositeNavigationBarViewData is now constructed in a more Fluent way
* @Nullable annotations have been removed because we generally don't want to  use @Nullable annotation to represent something as optional

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
