### PR TITLE
[Feature] Staggered Call Grid View

### DIFF
--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/ParticipantGridView.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/ParticipantGridView.kt
@@ -187,16 +187,15 @@ internal class ParticipantGridView : GridLayout {
         displayedRemoteParticipantsView: List<ParticipantGridCellView>,
     ) {
         when (displayedRemoteParticipantsView.size) {
-            SINGLE_PARTICIPANT, TWO_PARTICIPANTS, FOUR_PARTICIPANTS, SIX_PARTICIPANTS, EIGHT_PARTICIPANTS,
-            NINE_PARTICIPANTS, -> {
+            SINGLE_PARTICIPANT, TWO_PARTICIPANTS, FOUR_PARTICIPANTS, SIX_PARTICIPANTS, NINE_PARTICIPANTS, -> {
                 displayedRemoteParticipantsView.forEach {
                     addParticipantToGrid(
                         participantGridCellView = it
                     )
                 }
             }
-            THREE_PARTICIPANTS, FIVE_PARTICIPANTS, SEVEN_PARTICIPANTS -> {
-                // for 3, 5, or 7 number of participants, first participant will take two cells
+            THREE_PARTICIPANTS -> {
+                // for 3 first participant will take two cells
                 if (context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
                     addParticipantToGrid(
                         columnSpan = 2,
@@ -217,6 +216,156 @@ internal class ParticipantGridView : GridLayout {
                     }
                 }
             }
+            FIVE_PARTICIPANTS -> {
+                // for 5 number of participants, first participant will take two cells only on phones (< 7inch)
+                if (isTabletScreen()) {
+                    if (context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+                        addParticipantToGrid(
+                            columnSpan = 2,
+                            rowSpan = 3,
+                            participantGridCellView = displayedRemoteParticipantsView[0]
+                        )
+
+                        displayedRemoteParticipantsView.forEachIndexed { index, participantGridCellView ->
+                            if (index > 0) {
+                                if (index == 3) {
+                                    addParticipantToGrid(
+                                        columnSpan = 2,
+                                        rowSpan = 3,
+                                        participantGridCellView = participantGridCellView
+                                    )
+                                } else {
+                                    addParticipantToGrid(
+                                        columnSpan = 2,
+                                        rowSpan = 2,
+                                        participantGridCellView = participantGridCellView
+                                    )
+                                }
+                            }
+                        }
+                    } else {
+                        displayedRemoteParticipantsView.forEachIndexed { index, participantGridCellView ->
+                            if (index < 3) {
+                                addParticipantToGrid(
+                                    rowSpan = 2,
+                                    columnSpan = 2,
+                                    participantGridCellView = participantGridCellView
+                                )
+                            } else {
+                                addParticipantToGrid(
+                                    columnSpan = 3,
+                                    rowSpan = 2,
+                                    participantGridCellView = participantGridCellView
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    if (context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+                        addParticipantToGrid(
+                            columnSpan = 2,
+                            participantGridCellView = displayedRemoteParticipantsView[0]
+                        )
+                    } else {
+                        addParticipantToGrid(
+                            rowSpan = 2,
+                            participantGridCellView = displayedRemoteParticipantsView[0]
+                        )
+                    }
+
+                    displayedRemoteParticipantsView.forEachIndexed { index, participantGridCellView ->
+                        if (index > 0) {
+                            addParticipantToGrid(
+                                participantGridCellView = participantGridCellView
+                            )
+                        }
+                    }
+                }
+            }
+            SEVEN_PARTICIPANTS -> {
+                if (context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+                    addParticipantToGrid(
+                        rowSpan = 4,
+                        participantGridCellView = displayedRemoteParticipantsView[0]
+                    )
+                    addParticipantToGrid(
+                        rowSpan = 3,
+                        participantGridCellView = displayedRemoteParticipantsView[1]
+                    )
+                    displayedRemoteParticipantsView.forEachIndexed { index, participantGridCellView ->
+                        if (index > 1) {
+                            if (index % 2 == 0) {
+                                addParticipantToGrid(
+                                    rowSpan = 3,
+                                    participantGridCellView = participantGridCellView
+                                )
+                            } else {
+                                addParticipantToGrid(
+                                    rowSpan = 4,
+                                    participantGridCellView = participantGridCellView
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    displayedRemoteParticipantsView.forEachIndexed { index, participantGridCellView ->
+                        if (index < 4) {
+                            addParticipantToGrid(
+                                columnSpan = 3,
+                                participantGridCellView = participantGridCellView
+                            )
+                        } else {
+                            addParticipantToGrid(
+                                columnSpan = 4,
+                                participantGridCellView = participantGridCellView
+                            )
+                        }
+                    }
+                }
+            }
+            EIGHT_PARTICIPANTS -> {
+                if (context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+                    displayedRemoteParticipantsView.forEachIndexed { index, participantGridCellView ->
+                        if (index < 2) {
+                            addParticipantToGrid(
+                                rowSpan = 2,
+                                columnSpan = 3,
+                                participantGridCellView = participantGridCellView
+                            )
+                        } else {
+                            addParticipantToGrid(
+                                rowSpan = 2,
+                                columnSpan = 2,
+                                participantGridCellView = participantGridCellView
+                            )
+                        }
+                    }
+                } else {
+                    addParticipantToGrid(
+                        rowSpan = 3,
+                        columnSpan = 2,
+                        participantGridCellView = displayedRemoteParticipantsView[0]
+                    )
+
+                    displayedRemoteParticipantsView.forEachIndexed { index, participantGridCellView ->
+                        if (index > 0) {
+                            if (index == 5) {
+                                addParticipantToGrid(
+                                    rowSpan = 3,
+                                    columnSpan = 2,
+                                    participantGridCellView = participantGridCellView
+                                )
+                            } else {
+                                addParticipantToGrid(
+                                    rowSpan = 2,
+                                    columnSpan = 2,
+                                    participantGridCellView = participantGridCellView
+                                )
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -234,21 +383,38 @@ internal class ParticipantGridView : GridLayout {
             }
             3, 4 -> {
                 setGridRowsColumn(rows = 2, columns = 2)
-            }
-            5, 6 -> {
+            } 6 -> {
                 if (context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
                     setGridRowsColumn(rows = 3, columns = 2)
                 } else {
                     setGridRowsColumn(rows = 2, columns = 3)
                 }
-            } 7, 8 -> {
-                if (context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
-                    setGridRowsColumn(rows = 4, columns = 2)
+            }
+            5 -> {
+                if (isTabletScreen()) {
+                    if (context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+                        setGridRowsColumn(rows = 6, columns = 4)
+                    } else {
+                        setGridRowsColumn(rows = 4, columns = 6)
+                    }
                 } else {
-                    setGridRowsColumn(rows = 2, columns = 4)
+                    if (context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+                        setGridRowsColumn(rows = 3, columns = 2)
+                    } else {
+                        setGridRowsColumn(rows = 2, columns = 3)
+                    }
                 }
             }
-            9 -> {
+            7 -> {
+                if (context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+                    setGridRowsColumn(rows = 12, columns = 2)
+                } else {
+                    setGridRowsColumn(rows = 2, columns = 12)
+                }
+            }
+            8 -> {
+                setGridRowsColumn(rows = 6, columns = 6)
+            } 9 -> {
                 setGridRowsColumn(rows = 3, columns = 3)
             }
         }
@@ -263,13 +429,9 @@ internal class ParticipantGridView : GridLayout {
         val columnSpec = spec(UNDEFINED, columnSpan)
         val params = LayoutParams(rowSpec, columnSpec)
 
-        if (columnSpan != 2) {
-            params.width = this.width / this.columnCount
-        }
-
-        if (rowSpan != 2) {
-            params.height = this.height / this.rowCount
-        }
+        params.width = this.width / (this.columnCount / columnSpan)
+        params.height = this.height / (this.rowCount / rowSpan)
+        this.orientation = HORIZONTAL
 
         participantGridCellView.layoutParams = params
         detachFromParentView(participantGridCellView)
@@ -285,6 +447,10 @@ internal class ParticipantGridView : GridLayout {
         if (view != null && view.parent != null) {
             (view.parent as ViewGroup).removeView(view)
         }
+    }
+
+    private fun isTabletScreen(): Boolean {
+        return participantGridViewModel.getMaxRemoteParticipantsSize() == NINE_PARTICIPANTS
     }
 
     private fun createParticipantGridCellView(

--- a/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/ParticipantGridViewModel.kt
+++ b/azure-communication-ui/azure-communication-ui/src/calling/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/ParticipantGridViewModel.kt
@@ -44,6 +44,10 @@ internal class ParticipantGridViewModel(
         this.updateVideoStreamsCallback = callback
     }
 
+    fun getMaxRemoteParticipantsSize(): Int {
+        return maxRemoteParticipantSize
+    }
+
     fun getIsLobbyOverlayDisplayedFlow(): StateFlow<Boolean> = isLobbyOverlayDisplayedFlow
 
     fun updateIsLobbyOverlayDisplayed(callingStatus: CallingStatus) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Existing call grid layout changed to a staggered grid layout to align with iOS and Web.

Changes includes (n means # of remote participants):

- n = 5 layout change (only on tablets)

![5 land-tablet](https://user-images.githubusercontent.com/24381490/186876633-a3670f63-191a-48ae-bb46-4a0ffe592ed1.png)
![5 port-tablet](https://user-images.githubusercontent.com/24381490/186876651-632c2fa9-cdc3-4243-9986-7821b3712533.png)

- n = 5 layout on phones (screen < 7inch) will remain same:
![5 land-phone](https://user-images.githubusercontent.com/24381490/186876699-28b0140f-06d7-44ba-8b64-b194a2e2b257.png)

- n = 7, we did not show 7 remote participants but now we do:
![7 port](https://user-images.githubusercontent.com/24381490/186877026-7f8af276-ec87-4b4d-81c5-9663c50fdf07.png)
![7 land](https://user-images.githubusercontent.com/24381490/186877045-0bbd8a61-543c-4093-8983-4fd2ef527225.png)


- n = 8, changed from a 4x4 to this:
![8 land](https://user-images.githubusercontent.com/24381490/186877101-9fb7dbdd-c061-4c4c-adbb-337a5b1affb5.png)
![8 port](https://user-images.githubusercontent.com/24381490/186877116-3051cf0f-a75d-4f7b-ba04-40994756bd17.png)





## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [x] UI Changes
  - [x] Screen captures included
  - [x] Tested for Light/Dark mode
  - [x] Tested for screen rotation
  - [x] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
Please verify that all # of remote participants 0 - 9 are shown correctly in portrait and landscape.
Also verify that phone layout only goes up to 6 participants and tablets can go up to 9 participants, where n=5 is a new layout only on tablets

## Other Information
<!-- Add any other helpful information that may be needed here. -->
