### PR TITLE
[Calling][Refactoring] remote participants avatar not injected

### DIFF
--- a/azure-communication-ui/build.gradle
+++ b/azure-communication-ui/build.gradle
@@ -24,6 +24,7 @@ buildscript {
         androidx_lifecycle_viewmodel_ktx_version = '2.4.1'
         androidx_navigation_fragment_ktx_version = '2.4.2'
         androidx_test_rules_version = '1.4.1-alpha07'
+        androidx_activity_compose_version = "1.5.1"
 
         if (project.rootProject.file('private_drop.properties').canRead()) {
             Properties privateDropProps = new Properties()
@@ -38,6 +39,7 @@ buildscript {
 
         microsoft_dualscreen_layout_version = '1.0.0-alpha01'
         microsoft_fluent_ui_version = '0.0.20'
+        microsoft_fluent_ui_version_v2 = '0.1.2'
 
         mockito_inline_version = '4.3.1'
         mockito_kotlin_version = '4.0.0'
@@ -45,6 +47,8 @@ buildscript {
         shouldNotCheckTaskRoot = {
             return rootProject.hasProperty("disableTaskRootCheck") && rootProject.getProperty("disableTaskRootCheck")
         }
+
+        compose_version = '1.3.1'
     }
 
     repositories {

--- a/azure-communication-ui/build.gradle
+++ b/azure-communication-ui/build.gradle
@@ -35,6 +35,9 @@ buildscript {
             azure_calling_sdk_version = '2.2.0'
         }
 
+        azure_chat_sdk_version = '2.0.0'
+        azure_common_sdk_version = '1.0.2'
+
         jetbrains_kotlinx_coroutines_test_version = '1.6.0-native-mt'
 
         microsoft_dualscreen_layout_version = '1.0.0-alpha01'

--- a/azure-communication-ui/build.gradle
+++ b/azure-communication-ui/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         ui_library_version_name = '1.0.0'
         ui_library_version_code = getVersionCode()
 
-        kotlin_version = '1.6.10'
+        kotlin_version = '1.7.10'
         jacoco_version = '0.8.7'
         junit_version = '4.13.2'
 
@@ -51,7 +51,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
 

--- a/azure-communication-ui/call-with-chat/build.gradle
+++ b/azure-communication-ui/call-with-chat/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 31
 
     defaultConfig {
-        minSdk 21
+        minSdk 23
         targetSdk 31
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/CallCompositeActivity.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/CallCompositeActivity.kt
@@ -245,6 +245,7 @@ internal class CallCompositeActivity : AppCompatActivity() {
                 requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
                 launchFragment(SetupFragment::class.java.name)
             }
+            else -> {}
         }
     }
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/ControlBarView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/ControlBarView.kt
@@ -172,6 +172,7 @@ internal class ControlBarView : ConstraintLayout {
                 micToggle.isSelected = false
                 micToggle.contentDescription = context.getString(R.string.azure_communication_ui_calling_setup_view_button_mic_off)
             }
+            else -> {}
         }
     }
 
@@ -193,6 +194,7 @@ internal class ControlBarView : ConstraintLayout {
                     R.drawable.azure_communication_ui_calling_ic_fluent_speaker_bluetooth_24_regular
                 )
             }
+            else -> {}
         }
     }
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/ControlBarView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/ControlBarView.kt
@@ -101,13 +101,13 @@ internal class ControlBarView : ConstraintLayout {
 
     private val alwaysOffSelectedAccessibilityDelegate = object : AccessibilityDelegateCompat() {
         override fun onInitializeAccessibilityNodeInfo(
-            host: View?,
-            info: AccessibilityNodeInfoCompat?
+            host: View,
+            info: AccessibilityNodeInfoCompat
         ) {
             super.onInitializeAccessibilityNodeInfo(host, info)
             if (host in accessibilityNonSelectableViews()) {
                 // From an accessibility standpoint these views are never "selected"
-                info?.isSelected = false
+                info.isSelected = false
             }
         }
     }
@@ -117,11 +117,11 @@ internal class ControlBarView : ConstraintLayout {
             this,
             object : AccessibilityDelegateCompat() {
                 override fun onRequestSendAccessibilityEvent(
-                    host: ViewGroup?,
-                    child: View?,
-                    event: AccessibilityEvent?
+                    host: ViewGroup,
+                    child: View,
+                    event: AccessibilityEvent
                 ): Boolean {
-                    if (child in accessibilityNonSelectableViews() && event?.eventType == AccessibilityEvent.TYPE_VIEW_SELECTED) {
+                    if (child in accessibilityNonSelectableViews() && event.eventType == AccessibilityEvent.TYPE_VIEW_SELECTED) {
                         // We don't want Accessibility TalkBock to read out the "Selected" status of
                         // these views because that's just the way we've internally set up the
                         // icons to have different drawables based on the current status

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/SetupControlBarView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/SetupControlBarView.kt
@@ -113,6 +113,7 @@ internal class SetupControlBarView : LinearLayout {
                 micButton.isON = false
                 micButton.text = context.getString(R.string.azure_communication_ui_calling_setup_view_button_mic_off)
             }
+            else -> {}
         }
         micButton.refreshDrawableState()
     }
@@ -127,6 +128,7 @@ internal class SetupControlBarView : LinearLayout {
                 cameraButton.isON = false
                 cameraButton.text = context.getString(R.string.azure_communication_ui_calling_setup_view_button_video_off)
             }
+            else -> {}
         }
         cameraButton.refreshDrawableState()
     }

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/manager/AudioSessionManager.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/manager/AudioSessionManager.kt
@@ -239,6 +239,7 @@ internal class AudioSessionManager(
         when (audioDeviceSelectionStatus) {
             AudioDeviceSelectionStatus.SPEAKER_REQUESTED, AudioDeviceSelectionStatus.RECEIVER_REQUESTED, AudioDeviceSelectionStatus.BLUETOOTH_SCO_REQUESTED ->
                 switchAudioDevice(audioDeviceSelectionStatus)
+            else -> {}
         }
     }
 
@@ -268,6 +269,7 @@ internal class AudioSessionManager(
                     )
                 )
             }
+            else -> {}
         }
     }
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/redux/middleware/handler/CallingMiddlewareActionHandler.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/redux/middleware/handler/CallingMiddlewareActionHandler.kt
@@ -376,6 +376,7 @@ internal class CallingMiddlewareActionHandlerImpl(
                         CallingStatus.DISCONNECTED -> {
                             store.dispatch(NavigationAction.Exit())
                         }
+                        else -> {}
                     }
                 }
             }

--- a/azure-communication-ui/chat/build.gradle
+++ b/azure-communication-ui/chat/build.gradle
@@ -8,7 +8,7 @@ android {
     resourcePrefix 'azure_communication_ui_call_'
 
     defaultConfig {
-        minSdk 21
+        minSdk 23
         targetSdk 31
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -50,6 +50,9 @@ dependencies {
 
     implementation "com.microsoft.fluentui:fluentui_others:$microsoft_fluent_ui_version_v2"
     implementation "androidx.activity:activity-compose:$androidx_activity_compose_version"
+
+    api ("com.azure.android:azure-communication-chat:$azure_chat_sdk_version")
+    api ("com.azure.android:azure-communication-common:$azure_common_sdk_version")
 
     testImplementation "junit:junit:$junit_version"
     androidTestImplementation "androidx.test.ext:junit:$androidx_junit_version"

--- a/azure-communication-ui/chat/build.gradle
+++ b/azure-communication-ui/chat/build.gradle
@@ -28,6 +28,17 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion compose_version
+    }
+    packagingOptions {
+        resources {
+            excludes += '/META-INF/{AL2.0,LGPL2.1}'
+        }
+    }
 }
 
 dependencies {
@@ -36,6 +47,9 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
     implementation "androidx.fragment:fragment-ktx:$androidx_fragment_ktx_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$androidx_navigation_fragment_ktx_version"
+
+    implementation "com.microsoft.fluentui:fluentui_others:$microsoft_fluent_ui_version_v2"
+    implementation "androidx.activity:activity-compose:$androidx_activity_compose_version"
 
     testImplementation "junit:junit:$junit_version"
     androidTestImplementation "androidx.test.ext:junit:$androidx_junit_version"

--- a/azure-communication-ui/chat/src/main/AndroidManifest.xml
+++ b/azure-communication-ui/chat/src/main/AndroidManifest.xml
@@ -3,4 +3,11 @@
     package="com.azure.android.communication.ui.chat"
     >
 
+    <application>
+        <activity
+            android:name=".presentation.ChatCompositeActivity"
+            android:exported="false"
+            />
+    </application>
+
 </manifest>

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/ChatComposite.java
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/ChatComposite.java
@@ -3,5 +3,147 @@
 
 package com.azure.android.communication.ui.chat;
 
+import android.content.Context;
+import android.view.View;
+
+import com.azure.android.communication.common.CommunicationIdentifier;
+import com.azure.android.communication.ui.chat.configuration.ChatCompositeConfiguration;
+import com.azure.android.communication.ui.chat.models.ChatCompositeLocalOptions;
+import com.azure.android.communication.ui.chat.models.ChatCompositeLocalizationOptions;
+import com.azure.android.communication.ui.chat.models.ChatCompositeRemoteOptions;
+import com.azure.android.communication.ui.chat.models.ChatCompositeUnreadMessageChangedEvent;
+
+/**
+ * Azure android communication chat composite component.
+ *
+ * <p><strong>Instantiating Chat Composite</strong></p>
+ */
 public class ChatComposite {
+
+    private static int instanceIdCounter = 0;
+
+    private final ChatContainer chatContainer;
+    private final int instanceId;
+    private final ChatCompositeLocalizationOptions chatCompositeLocalizationOptions;
+
+
+    ChatComposite(final ChatCompositeConfiguration configuration) {
+        instanceId = instanceIdCounter++;
+        chatCompositeLocalizationOptions = configuration.getLocalizationConfig();
+        chatContainer = new ChatContainer(configuration, instanceId);
+    }
+
+    /**
+     * Launch group chat composite.
+     *
+     * @param context       The android context used to start the Composite.
+     * @param remoteOptions The {@link ChatCompositeRemoteOptions} has remote parameters to
+     *                      launch group chat experience.
+     */
+    public void launch(final Context context, final ChatCompositeRemoteOptions remoteOptions) {
+        launch(context, remoteOptions, null);
+    }
+
+    /**
+     * Launch group chat composite.
+     *
+     * @param context       The android context used to start the Composite.
+     * @param remoteOptions The {@link ChatCompositeRemoteOptions} has remote parameters to
+     *                      launch group chat experience.
+     * @param localOptions  The {@link ChatCompositeLocalOptions} has local parameters to
+     *                      launch group chat experience.
+     */
+    public void launch(final Context context,
+                       final ChatCompositeRemoteOptions remoteOptions,
+                       final ChatCompositeLocalOptions localOptions) {
+        launchComposite(context, remoteOptions, localOptions, false);
+    }
+
+    /**
+     * Stop the ChatComposite. Destroy the UI if in foreground mode. Destroy service layer.
+     */
+    public void stop() {
+        chatContainer.stop();
+    }
+
+    private void launchComposite(final Context context,
+                                 final ChatCompositeRemoteOptions remoteOptions,
+                                 final ChatCompositeLocalOptions localOptions,
+                                 final boolean isTest) {
+    }
+
+    /**
+     * Get Composite UI view
+     *
+     * @param context The android context used to start the Composite.\
+     * @return View ChatComposite UI view
+     */
+    public View getCompositeUIView(final Context context) {
+        return null;
+    }
+
+    /**
+     * To show full composite default view
+     *
+     * @param context The android context used to start the Composite.
+     */
+    public void showCompositeUI(final Context context) {
+    }
+
+    /**
+     * To hide full composite view
+     *
+     * @param context The android context used to start the Composite.
+     */
+    public void hideCompositeUI(final Context context) {
+    }
+
+    /**
+     * Add {@link ChatCompositeEventHandler}.
+     *
+     * @param handler The {@link ChatCompositeEventHandler}.
+     */
+    public void addOnViewClosedEventHandler(final ChatCompositeEventHandler<Object> handler) {
+    }
+
+    /**
+     * Remove {@link ChatCompositeEventHandler}.
+     *
+     * @param handler The {@link ChatCompositeEventHandler}.
+     */
+    public void removeOnViewClosedEventHandler(final ChatCompositeEventHandler<Object> handler) {
+    }
+
+    /**
+     * Add {@link ChatCompositeEventHandler} with {@link ChatCompositeUnreadMessageChangedEvent}.
+     *
+     * @param handler The {@link ChatCompositeEventHandler}.
+     */
+    public void addOnUnreadMessagesChangedEventHandler(
+            final ChatCompositeEventHandler<ChatCompositeUnreadMessageChangedEvent> handler) {
+    }
+
+    /**
+     * Remove {@link ChatCompositeEventHandler} with {@link ChatCompositeUnreadMessageChangedEvent}.
+     *
+     * @param handler The {@link ChatCompositeEventHandler}.
+     */
+    public void removeOnUnreadMessagesChangedEventHandler(
+            final ChatCompositeEventHandler<ChatCompositeUnreadMessageChangedEvent> handler) {
+
+    }
+
+    /**
+     * Set {@link ChatCompositeRemoteOptions}.
+     *
+     * <p>
+     * Used to set Participant View Data (E.g. Avatar and displayName) to be used on this device only.
+     * </p>
+     *
+     * @param participantViewData The {@link ChatCompositeRemoteOptions}.
+     * @param identifier          The {@link CommunicationIdentifier}.
+     */
+    public void setChatCompositeRemoteOptions(final ChatCompositeRemoteOptions participantViewData,
+                                              final CommunicationIdentifier identifier) {
+    }
 }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/ChatCompositeEventHandler.java
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/ChatCompositeEventHandler.java
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.communication.ui.chat;
+
+public interface ChatCompositeEventHandler<T> {
+    /**
+     * A callback method to process error event of type T
+     *
+     * @param eventArgs {@link T}
+     */
+    void handle(T eventArgs);
+}

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/ChatContainer.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/ChatContainer.kt
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.communication.ui.chat
+
+import android.content.Context
+import com.azure.android.communication.ui.chat.configuration.ChatCompositeConfiguration
+import com.azure.android.communication.ui.chat.locator.ServiceLocator
+import com.azure.android.communication.ui.chat.models.ChatCompositeLocalOptions
+import com.azure.android.communication.ui.chat.models.ChatCompositeRemoteOptions
+import com.azure.android.communication.ui.chat.models.ChatCompositeUnreadMessageChangedEvent
+
+internal class ChatContainer(
+    private val configuration: ChatCompositeConfiguration,
+    private val instanceId: Int,
+) {
+    var started = false
+    private val locator = ServiceLocator.getInstance(instanceId = instanceId)
+    private val onUnreadMessageChangedHandlers =
+        mutableSetOf<ChatCompositeEventHandler<ChatCompositeUnreadMessageChangedEvent>>()
+
+    private fun start(
+        context: Context,
+        remoteOptions: ChatCompositeRemoteOptions,
+        localOptions: ChatCompositeLocalOptions,
+    ) {
+    }
+
+    fun addOnViewClosedEventHandler(handler: ChatCompositeEventHandler<Any>) {
+    }
+
+    fun removeOnViewClosedEventHandler(handler: ChatCompositeEventHandler<Any>) {
+    }
+
+    fun addOnUnreadMessagesChangedEventHandler(handler: ChatCompositeEventHandler<ChatCompositeUnreadMessageChangedEvent>) {
+        onUnreadMessageChangedHandlers.add(handler)
+    }
+
+    fun removeOnUnreadMessagesChangedEventHandler(handler: ChatCompositeEventHandler<ChatCompositeUnreadMessageChangedEvent>) {
+        onUnreadMessageChangedHandlers.remove(handler)
+    }
+
+    fun stop() {
+        locator.clear()
+    }
+}

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/configuration/ChatCompositeConfiguration.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/configuration/ChatCompositeConfiguration.kt
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.communication.ui.chat.configuration
+
+import com.azure.android.communication.ui.chat.models.ChatCompositeLocalizationOptions
+
+internal class ChatCompositeConfiguration(
+    var localizationConfig: ChatCompositeLocalizationOptions? = null,
+)

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/ChatCompositeJoinLocator.java
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/ChatCompositeJoinLocator.java
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.communication.ui.chat.models;
+
+public abstract class ChatCompositeJoinLocator {
+}

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/ChatCompositeLocalOptions.java
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/ChatCompositeLocalOptions.java
@@ -31,7 +31,15 @@ import com.azure.android.communication.ui.chat.ChatComposite;
  * @see ChatComposite
  */
 public final class ChatCompositeLocalOptions {
-    private final ChatCompositeParticipantViewData participantViewData;
+    private boolean isLaunchingWithUI = true;
+    private ChatCompositeParticipantViewData participantViewData;
+
+    /**
+     * Create Local Options with default setting.
+     */
+    public ChatCompositeLocalOptions() {
+
+    }
 
     /**
      * Create Local Options.
@@ -50,5 +58,24 @@ public final class ChatCompositeLocalOptions {
      */
     public ChatCompositeParticipantViewData getParticipantViewData() {
         return participantViewData;
+    }
+
+    /**
+     * Get is launching with UI boolean
+     *
+     * @return boolean isLaunchingWithUI;
+     */
+    public boolean getIsLaunchingWithUI() {
+        return isLaunchingWithUI;
+    }
+
+    /**
+     * Set is launching with UI boolean
+     *
+     * @return The {@link ChatCompositeLocalOptions };
+     */
+    public ChatCompositeLocalOptions setLaunchingWithUI(final boolean isLaunchingWithUI) {
+        this.isLaunchingWithUI = isLaunchingWithUI;
+        return this;
     }
 }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/ChatCompositeLocalizationOptions.java
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/ChatCompositeLocalizationOptions.java
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+
+package com.azure.android.communication.ui.chat.models;
+
+import androidx.annotation.NonNull;
+
+import java.util.Locale;
+
+public final class ChatCompositeLocalizationOptions {
+    private Integer layoutDirection;
+    private final Locale locale;
+
+    /**
+     * Create Localization configuration.
+     *
+     * @param locale The {@link Locale}; eg,. {@code Locale.US}
+     */
+    public ChatCompositeLocalizationOptions(@NonNull final Locale locale) {
+        this.locale = locale;
+    }
+
+    /**
+     * Create Localization configuration.
+     *
+     * @param locale          The {@link Locale}; eg,. {@code Locale.US}
+     * @param layoutDirection layout direction int; eg,. {@code LayoutDirection.RTL}
+     */
+    public ChatCompositeLocalizationOptions(@NonNull final Locale locale, final int layoutDirection) {
+        this.locale = locale;
+        this.layoutDirection = layoutDirection;
+    }
+
+    /**
+     * Get current {@link Locale}.
+     *
+     * @return The {@link Locale}.
+     */
+    public Locale getLocale() {
+        return locale;
+    }
+
+    /**
+     * Get layoutDirection {@link Integer}.
+     *
+     * @return layoutDirection {@link Integer}.
+     */
+    public Integer getLayoutDirection() {
+        return layoutDirection;
+    }
+}

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/ChatCompositeRemoteOptions.java
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/ChatCompositeRemoteOptions.java
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.communication.ui.chat.models;
+
+import com.azure.android.communication.common.CommunicationTokenCredential;
+
+public class ChatCompositeRemoteOptions {
+
+    private final CommunicationTokenCredential credential;
+    private final ChatCompositeJoinLocator locator;
+    private final String displayName;
+
+    /**
+     * Create {@link ChatCompositeRemoteOptions}.
+     *
+     * @param locator    {@link ChatCompositeJoinLocator}
+     * @param credential {@link CommunicationTokenCredential}.
+     */
+    public ChatCompositeRemoteOptions(
+            final ChatCompositeJoinLocator locator,
+            final CommunicationTokenCredential credential) {
+        this(locator, credential, "");
+    }
+
+    /**
+     * Create {@link ChatCompositeRemoteOptions}.
+     *
+     * @param locator     {@link ChatCompositeJoinLocator}
+     * @param credential  {@link CommunicationTokenCredential}
+     * @param displayName User display name other participants will see.
+     */
+    public ChatCompositeRemoteOptions(
+            final ChatCompositeJoinLocator locator,
+            final CommunicationTokenCredential credential,
+            final String displayName) {
+
+        this.credential = credential;
+        this.displayName = displayName;
+        this.locator = locator;
+    }
+
+    /**
+     * Get {@link CommunicationTokenCredential}.
+     *
+     * @return {@link String}.
+     */
+    public CommunicationTokenCredential getCredential() {
+        return credential;
+    }
+
+    /**
+     * Get chat locator.
+     *
+     * @return {@link ChatCompositeJoinLocator}.
+     */
+    public ChatCompositeJoinLocator getLocator() {
+        return locator;
+    }
+
+    /**
+     * Get {@link CommunicationTokenCredential}.
+     *
+     * @return {@link String}.
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/ChatCompositeUnreadMessageChangedEvent.java
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/ChatCompositeUnreadMessageChangedEvent.java
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.communication.ui.chat.models;
+
+public class ChatCompositeUnreadMessageChangedEvent {
+    private final int count;
+
+    public ChatCompositeUnreadMessageChangedEvent(final int count) {
+        this.count = count;
+    }
+
+    /**
+     * Get unread message changed count.
+     *
+     * @return int count.
+     */
+    public int getCount() {
+        return count;
+    }
+}

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ChatCompositeActivity.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ChatCompositeActivity.kt
@@ -3,6 +3,16 @@
 
 package com.azure.android.communication.ui.chat.presentation
 
+import android.os.Bundle
+import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.text.BasicText
 
-internal class ChatCompositeActivity : AppCompatActivity()
+internal class ChatCompositeActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            BasicText(text = "Hello Chat!")
+        }
+    }
+}

--- a/azure-communication-ui/demo-app/build.gradle
+++ b/azure-communication-ui/demo-app/build.gradle
@@ -13,7 +13,6 @@ android {
 
     defaultConfig {
         applicationId "com.azure.android.communication.ui.callingcompositedemoapp"
-        minSdkVersion 21
         targetSdkVersion 31
         versionCode ui_library_version_code
         versionName "$ui_library_version_name"
@@ -117,14 +116,17 @@ android {
     productFlavors {
 
         calling {
+            minSdkVersion 21
             dimension "product"
             matchingFallbacks = ["calling"]
         }
         chat {
+            minSdkVersion 23
             dimension "product"
             matchingFallbacks = ["chat"]
         }
         callwithchat {
+            minSdkVersion 23
             dimension "product"
             matchingFallbacks = ["callwithchat"]
         }

--- a/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/RemoteParticipantJoinedHandler.kt
+++ b/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/RemoteParticipantJoinedHandler.kt
@@ -81,7 +81,11 @@ class RemoteParticipantJoinedHandler(
                         R.drawable.image_koala,
                         R.drawable.image_monkey,
                         R.drawable.image_mouse,
-                        R.drawable.image_octopus
+                        R.drawable.image_octopus,
+                        R.drawable.image_cat,
+                        R.drawable.image_fox,
+                        R.drawable.image_koala,
+                        R.drawable.image_monkey,
                     )
                     images[number].let {
                         val bitMap =


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Issue: turning on inject avatar is not working
* Cause: image is not injected if last digit of ID of joining participant is greater than 5 or is char. Not a bug, I think during bug bash this scenario not met.
* Fix: increased randomness of injecting avatar if last digit exists

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:
