### PR TITLE
[Calling][Refactoring] remote participants avatar not injected

### DIFF
--- a/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/RemoteParticipantJoinedHandler.kt
+++ b/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/RemoteParticipantJoinedHandler.kt
@@ -81,7 +81,11 @@ class RemoteParticipantJoinedHandler(
                         R.drawable.image_koala,
                         R.drawable.image_monkey,
                         R.drawable.image_mouse,
-                        R.drawable.image_octopus
+                        R.drawable.image_octopus,
+                        R.drawable.image_cat,
+                        R.drawable.image_fox,
+                        R.drawable.image_koala,
+                        R.drawable.image_monkey,
                     )
                     images[number].let {
                         val bitMap =


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Issue: turning on inject avatar is not working
* Cause: image is not injected if last digit of ID of joining participant is greater than 5 or is char. Not a bug, I think during bug bash this scenario not met.
* Fix: increased randomness of injecting avatar if last digit exists

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:
