### PR TITLE
[Calling][Bug] camera stream is not visible to remote participant after call resume from background mode

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/redux/middleware/handler/CallingMiddlewareActionHandler.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/redux/middleware/handler/CallingMiddlewareActionHandler.kt
@@ -7,7 +7,6 @@ import com.azure.android.communication.ui.calling.error.ErrorCode
 import com.azure.android.communication.ui.calling.models.CallCompositeEventCode
 import com.azure.android.communication.ui.calling.error.CallCompositeError
 import com.azure.android.communication.ui.calling.error.FatalError
-import com.azure.android.communication.ui.calling.redux.AppStore
 import com.azure.android.communication.ui.calling.redux.Store
 import com.azure.android.communication.ui.calling.redux.action.CallingAction
 import com.azure.android.communication.ui.calling.redux.action.ErrorAction
@@ -24,7 +23,6 @@ import com.azure.android.communication.ui.calling.redux.state.PermissionStatus
 import com.azure.android.communication.ui.calling.redux.state.ReduxState
 import com.azure.android.communication.ui.calling.service.CallingService
 import com.azure.android.communication.ui.calling.utilities.CoroutineContextProvider
-import java9.util.concurrent.CompletableFuture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
@@ -96,7 +94,6 @@ internal class CallingMiddlewareActionHandlerImpl(
         if (state.callState.callingStatus != CallingStatus.LOCAL_HOLD) {
             tryCameraOn(store)
         }
-
     }
 
     override fun onCameraPermissionIsSet(store: Store<ReduxState>) {

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandlerUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandlerUnitTest.kt
@@ -1073,6 +1073,53 @@ internal class CallingMiddlewareActionHandlerUnitTest : ACSBaseTestCoroutine() {
     }
 
     @Test
+    fun callingMiddlewareActionHandler_enterForeground_then_not_dispatch_OnCameraStateChange_if_stateIsLocalHold() {
+        // arrange
+        val appState = AppReduxState("")
+        appState.localParticipantState = LocalUserState(
+            CameraState(
+                CameraOperationalStatus.PAUSED,
+                CameraDeviceSelectionStatus.FRONT,
+                CameraTransmissionStatus.LOCAL
+            ),
+            AudioState(
+                AudioOperationalStatus.OFF,
+                AudioDeviceSelectionStatus.SPEAKER_SELECTED,
+                BluetoothState(available = false, deviceName = "bluetooth")
+            ),
+            videoStreamID = null,
+            displayName = "username"
+        )
+        appState.navigationState = NavigationState(NavigationStatus.IN_CALL)
+        appState.callState = CallingState(CallingStatus.LOCAL_HOLD)
+
+        val cameraStateCompletableFuture = CompletableFuture<String>()
+
+        val mockCallingService: CallingService = mock {}
+        val handler = CallingMiddlewareActionHandlerImpl(
+            mockCallingService,
+            UnconfinedTestContextProvider()
+        )
+
+        val mockAppStore = mock<AppStore<ReduxState>> {
+            on { getCurrentState() } doReturn appState
+            on { dispatch(any()) } doAnswer { }
+        }
+
+        // act
+        handler.enterForeground(mockAppStore)
+        cameraStateCompletableFuture.complete("streamId")
+
+        // assert
+        verify(
+            mockAppStore,
+            times(1)
+        ).dispatch(argThat { action -> action is LifecycleAction.EnterForegroundSucceeded })
+
+        verify(mockCallingService, times(0)).turnCameraOn()
+    }
+
+    @Test
     fun callingMiddlewareActionHandler_enterForeground_then_dispatch_DoNotTurnCameraOnIfWasNotPaused() {
         // arrange
         val appState = AppReduxState("")
@@ -1410,6 +1457,74 @@ internal class CallingMiddlewareActionHandlerUnitTest : ACSBaseTestCoroutine() {
 
     @ExperimentalCoroutinesApi
     @Test
+    fun callingMiddlewareActionHandler_onSubscribeCallInfoModelUpdate_then_dispatch_turnCameraOn() =
+        runScopedTest {
+            // arrange
+            val appState = AppReduxState("")
+            appState.localParticipantState = LocalUserState(
+                CameraState(
+                    CameraOperationalStatus.PAUSED,
+                    CameraDeviceSelectionStatus.FRONT,
+                    CameraTransmissionStatus.LOCAL
+                ),
+                AudioState(
+                    AudioOperationalStatus.OFF,
+                    AudioDeviceSelectionStatus.SPEAKER_SELECTED,
+                    BluetoothState(available = false, deviceName = "bluetooth")
+                ),
+                videoStreamID = null,
+                displayName = "username"
+            )
+            appState.callState = CallingState(CallingStatus.LOCAL_HOLD)
+
+            val callingServiceParticipantsSharedFlow =
+                MutableSharedFlow<MutableMap<String, ParticipantInfoModel>>()
+            val callInfoModelStateFlow =
+                MutableStateFlow(CallInfoModel(CallingStatus.LOCAL_HOLD, null))
+            val isMutedSharedFlow = MutableSharedFlow<Boolean>()
+            val isRecordingSharedFlow = MutableSharedFlow<Boolean>()
+            val isTranscribingSharedFlow = MutableSharedFlow<Boolean>()
+            val cameraStateCompletableFuture = CompletableFuture<String>()
+
+            val mockCallingService: CallingService = mock {
+                on { getParticipantsInfoModelSharedFlow() } doReturn callingServiceParticipantsSharedFlow
+                on { startCall(any(), any()) } doReturn CompletableFuture<Void>()
+                on { getCallInfoModelEventSharedFlow() } doReturn callInfoModelStateFlow
+                on { getIsMutedSharedFlow() } doReturn isMutedSharedFlow
+                on { getIsRecordingSharedFlow() } doReturn isRecordingSharedFlow
+                on { getIsTranscribingSharedFlow() } doReturn isTranscribingSharedFlow
+                on { turnCameraOn() } doReturn cameraStateCompletableFuture
+            }
+
+            val handler = CallingMiddlewareActionHandlerImpl(
+                mockCallingService,
+                UnconfinedTestContextProvider()
+            )
+
+            val mockAppStore = mock<AppStore<ReduxState>> {
+                on { dispatch(any()) } doAnswer { }
+                on { getCurrentState() } doAnswer { appState }
+            }
+
+            // act
+            handler.startCall(mockAppStore)
+            cameraStateCompletableFuture.complete("1345")
+            callInfoModelStateFlow.value = CallInfoModel(
+                CallingStatus.CONNECTED,
+                null
+            )
+
+            // assert
+            verify(mockAppStore, times(1)).dispatch(
+                argThat { action ->
+                    action is LocalParticipantAction.CameraOnSucceeded &&
+                        action.videoStreamID == "1345"
+                }
+            )
+        }
+
+    @ExperimentalCoroutinesApi
+    @Test
     fun callingMiddlewareActionHandler_onSubscribeCallInfoModelUpdate_then_dispatch_CallDecline() =
         runScopedTest {
             // arrange
@@ -1471,6 +1586,7 @@ internal class CallingMiddlewareActionHandlerUnitTest : ACSBaseTestCoroutine() {
                 }
             )
         }
+
     @ExperimentalCoroutinesApi
     @Test
     fun callingMiddlewareActionHandler_onSubscribeCallInfoModelUpdate_then_verify_CallDecline_Sequence() =
@@ -1871,6 +1987,7 @@ internal class CallingMiddlewareActionHandlerUnitTest : ACSBaseTestCoroutine() {
                 }
             )
         }
+
 
     private fun provideAppStore(): AppStore<ReduxState> {
         val appState = AppReduxState("CallingMiddleWareActionHandlerUnitTest")

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandlerUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandlerUnitTest.kt
@@ -1988,7 +1988,6 @@ internal class CallingMiddlewareActionHandlerUnitTest : ACSBaseTestCoroutine() {
             )
         }
 
-
     private fun provideAppStore(): AppStore<ReduxState> {
         val appState = AppReduxState("CallingMiddleWareActionHandlerUnitTest")
         return mock {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Resume call on hold from background mode, does not show video stream to remote participants

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [x] Tested for background mode
  - [x] Unit Tests Included
  - [ ] UI Automated Tests Included
