### PR TITLE
[Calling][Bug] Video stream not send to remote after joining with video camera turned on

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDKWrapper.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDKWrapper.kt
@@ -49,7 +49,7 @@ internal class CallingSDKWrapper(
     private var localVideoStreamCompletableFuture: CompletableFuture<LocalVideoStream>? = null
     private var endCallCompletableFuture: CompletableFuture<Void>? = null
     private var camerasInitializedCompletableFuture: CompletableFuture<Void>? = null
-    private var setupCallCompletableFuture: CompletableFuture<Void>? = null
+    private var setupCallCompletableFuture: CompletableFuture<Void> = CompletableFuture()
 
     private val configuration get() = CallCompositeConfiguration.getConfig(instanceId)
     private var videoDevicesUpdatedListener: VideoDevicesUpdatedListener? = null
@@ -144,15 +144,14 @@ internal class CallingSDKWrapper(
             }
             callClient = CallClient(callClientOptions)
         }
-        setupCallCompletableFuture = CompletableFuture()
         createDeviceManager().handle { _, error: Throwable? ->
             if (error != null) {
-                setupCallCompletableFuture?.completeExceptionally(error)
+                setupCallCompletableFuture.completeExceptionally(error)
             } else {
-                setupCallCompletableFuture?.complete(null)
+                setupCallCompletableFuture.complete(null)
             }
         }
-        return setupCallCompletableFuture!!
+        return setupCallCompletableFuture
     }
 
     override fun startCall(
@@ -290,7 +289,7 @@ internal class CallingSDKWrapper(
 
     override fun getLocalVideoStream(): CompletableFuture<LocalVideoStream> {
         val result = CompletableFuture<LocalVideoStream>()
-        setupCallCompletableFuture?.whenComplete { _, error ->
+        setupCallCompletableFuture.whenComplete { _, error ->
             if (error == null) {
                 val localVideoStreamCompletableFuture = getLocalVideoStreamCompletableFuture()
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDKWrapper.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDKWrapper.kt
@@ -49,6 +49,7 @@ internal class CallingSDKWrapper(
     private var localVideoStreamCompletableFuture: CompletableFuture<LocalVideoStream>? = null
     private var endCallCompletableFuture: CompletableFuture<Void>? = null
     private var camerasInitializedCompletableFuture: CompletableFuture<Void>? = null
+    private var setupCallCompletableFuture: CompletableFuture<Void>? = null
 
     private val configuration get() = CallCompositeConfiguration.getConfig(instanceId)
     private var videoDevicesUpdatedListener: VideoDevicesUpdatedListener? = null
@@ -143,15 +144,15 @@ internal class CallingSDKWrapper(
             }
             callClient = CallClient(callClientOptions)
         }
-        val setupCallCompletableFuture: CompletableFuture<Void> = CompletableFuture()
+        setupCallCompletableFuture = CompletableFuture()
         createDeviceManager().handle { _, error: Throwable? ->
             if (error != null) {
-                setupCallCompletableFuture.completeExceptionally(error)
+                setupCallCompletableFuture?.completeExceptionally(error)
             } else {
-                setupCallCompletableFuture.complete(null)
+                setupCallCompletableFuture?.complete(null)
             }
         }
-        return setupCallCompletableFuture
+        return setupCallCompletableFuture!!
     }
 
     override fun startCall(
@@ -289,27 +290,35 @@ internal class CallingSDKWrapper(
 
     override fun getLocalVideoStream(): CompletableFuture<LocalVideoStream> {
         val result = CompletableFuture<LocalVideoStream>()
+        setupCallCompletableFuture?.whenComplete { _, error ->
+            if (error == null) {
+                val localVideoStreamCompletableFuture = getLocalVideoStreamCompletableFuture()
 
-        val localVideoStreamCompletableFuture = getLocalVideoStreamCompletableFuture()
-
-        if (localVideoStreamCompletableFuture.isDone) {
-            result.complete(localVideoStreamCompletableFuture.get())
-        } else if (!canCreateLocalVideostream()) {
-            // cleanUpResources() could have been called before this, so we need to check if it's still
-            // alright to call initializeCameras()
-            result.complete(null)
-        } else {
-            initializeCameras().whenComplete { _, error ->
-                if (error != null) {
-                    localVideoStreamCompletableFuture.completeExceptionally(error)
-                    result.completeExceptionally(error)
-                } else {
-                    val desiredCamera = getCamera(CameraFacing.FRONT)
-
-                    localVideoStreamCompletableFuture.complete(
-                        LocalVideoStreamWrapper(NativeLocalVideoStream(desiredCamera, context))
-                    )
+                if (localVideoStreamCompletableFuture.isDone) {
                     result.complete(localVideoStreamCompletableFuture.get())
+                } else if (!canCreateLocalVideostream()) {
+                    // cleanUpResources() could have been called before this, so we need to check if it's still
+                    // alright to call initializeCameras()
+                    result.complete(null)
+                } else {
+                    initializeCameras().whenComplete { _, error ->
+                        if (error != null) {
+                            localVideoStreamCompletableFuture.completeExceptionally(error)
+                            result.completeExceptionally(error)
+                        } else {
+                            val desiredCamera = getCamera(CameraFacing.FRONT)
+
+                            localVideoStreamCompletableFuture.complete(
+                                LocalVideoStreamWrapper(
+                                    NativeLocalVideoStream(
+                                        desiredCamera,
+                                        context
+                                    )
+                                )
+                            )
+                            result.complete(localVideoStreamCompletableFuture.get())
+                        }
+                    }
                 }
             }
         }
@@ -368,7 +377,6 @@ internal class CallingSDKWrapper(
 
     private fun createDeviceManager(): CompletableFuture<DeviceManager> {
         val deviceManagerCompletableFuture = getDeviceManagerCompletableFuture()
-
         if (deviceManagerCompletableFuture.isCompletedExceptionally ||
             !deviceManagerCompletableFuture.isDone
         ) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Issue: Video stream not send to remote after joining with video camera turned on
* Root cause: get local stream was called before initialization of device manager. It is random issue as timing matters.
* Proposed fix: local stream future will return response once device manager is initialized

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

