### PR TITLE
[Calling][Bug] video not visible to remote participants on join

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/SetupViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/SetupViewModel.kt
@@ -80,7 +80,11 @@ internal class SetupViewModel(
             state.permissionState,
         )
 
-        joinCallButtonHolderViewModel.init(state.permissionState.audioPermissionState)
+        joinCallButtonHolderViewModel.init(
+            state.permissionState.audioPermissionState,
+            state.permissionState.cameraPermissionState,
+            state.localParticipantState.cameraState.operation
+        )
 
         super.init(coroutineScope)
     }
@@ -113,7 +117,9 @@ internal class SetupViewModel(
         )
         joinCallButtonHolderViewModel.update(
             state.permissionState.audioPermissionState,
-            state.callState
+            state.callState,
+            state.permissionState.cameraPermissionState,
+            state.localParticipantState.cameraState.operation
         )
     }
 }

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/JoinCallButtonHolderViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/JoinCallButtonHolderViewModel.kt
@@ -11,6 +11,7 @@ import com.azure.android.communication.ui.calling.redux.action.ErrorAction
 import com.azure.android.communication.ui.calling.redux.state.CallingState
 import com.azure.android.communication.ui.calling.redux.state.CallingStatus
 import com.azure.android.communication.ui.calling.redux.state.PermissionStatus
+import com.azure.android.communication.ui.calling.redux.state.CameraOperationalStatus
 import com.azure.android.communication.ui.calling.redux.state.isDisconnected
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -29,15 +30,31 @@ internal class JoinCallButtonHolderViewModel(private val dispatch: (Action) -> U
         disableJoinCallButtonFlow.value = true
     }
 
-    fun init(audioPermissionState: PermissionStatus) {
+    fun init(
+        audioPermissionState: PermissionStatus,
+        cameraPermissionState: PermissionStatus,
+        cameraOperationalStatus: CameraOperationalStatus
+    ) {
         joinCallButtonEnabledFlow =
-            MutableStateFlow(audioPermissionState == PermissionStatus.GRANTED)
+            MutableStateFlow(
+                audioPermissionState == PermissionStatus.GRANTED &&
+                    cameraPermissionState != PermissionStatus.UNKNOWN &&
+                    cameraOperationalStatus != CameraOperationalStatus.PENDING
+            )
         disableJoinCallButtonFlow.value = false
     }
 
-    fun update(audioPermissionState: PermissionStatus, callingState: CallingState) {
+    fun update(
+        audioPermissionState: PermissionStatus,
+        callingState: CallingState,
+        cameraPermissionState: PermissionStatus,
+        cameraOperationalStatus: CameraOperationalStatus
+    ) {
         disableJoinCallButtonFlow.value = callingState.callingStatus != CallingStatus.NONE
-        joinCallButtonEnabledFlow.value = audioPermissionState == PermissionStatus.GRANTED
+        joinCallButtonEnabledFlow.value =
+            audioPermissionState == PermissionStatus.GRANTED &&
+            cameraPermissionState != PermissionStatus.UNKNOWN &&
+            cameraOperationalStatus != CameraOperationalStatus.PENDING
         if (callingState.isDisconnected()) {
             disableJoinCallButtonFlow.value = false
         } else {

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/presentation/fragment/setup/components/JoinCallButtonHolderViewModelUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/presentation/fragment/setup/components/JoinCallButtonHolderViewModelUnitTest.kt
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package com.azure.android.communication.ui.presentation.fragment.setup.components
 
 import com.azure.android.communication.ui.calling.presentation.fragment.setup.components.JoinCallButtonHolderViewModel


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Bug: video not visible to remote participants on call join
* Cause: if user press join call when camera on is in progress, call is joined while redux state update is in progress. Thus service layer joins calls with video off
* Proposed fix: wait until camera permissions are not in progress as well as camera operation is not in progress 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

