### PR TITLE
[Chat][Feature] Disable send button when message is empty 

### DIFF
--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/BottomBarView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/BottomBarView.kt
@@ -53,7 +53,7 @@ internal fun BottomBarView(
 }
 
 private fun sendButtonOnclick(postAction: (Action) -> Unit, messageInputTextState: MutableState<String>) {
-   if (messageInputTextState.value.isBlank()) return
+    if (messageInputTextState.value.isBlank()) return
     postAction(
         ChatAction.SendMessage(
             MessageInfoModel(

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/BottomBarView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/BottomBarView.kt
@@ -45,7 +45,8 @@ internal fun BottomBarView(
 
         SendMessageButtonView(
             contentDescription = stringResource(R.string.azure_communication_ui_chat_message_send_button_content_description, messageInputTextState.value),
-            chatStatus = chatStatus
+            chatStatus = chatStatus,
+            clickable = messageInputTextState.value.isNotBlank()
         ) {
             sendButtonOnclick(postAction, messageInputTextState)
         }
@@ -53,7 +54,6 @@ internal fun BottomBarView(
 }
 
 private fun sendButtonOnclick(postAction: (Action) -> Unit, messageInputTextState: MutableState<String>) {
-    if (messageInputTextState.value.isBlank()) return
     postAction(
         ChatAction.SendMessage(
             MessageInfoModel(

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/BottomBarView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/BottomBarView.kt
@@ -53,6 +53,7 @@ internal fun BottomBarView(
 }
 
 private fun sendButtonOnclick(postAction: (Action) -> Unit, messageInputTextState: MutableState<String>) {
+   if (messageInputTextState.value.isBlank()) return
     postAction(
         ChatAction.SendMessage(
             MessageInfoModel(

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
@@ -26,7 +25,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.azure.android.communication.ui.chat.R
 import com.azure.android.communication.ui.chat.presentation.style.ChatCompositeTheme
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
@@ -112,7 +112,7 @@ internal fun MessageInput(
 
                 if (textContent.isEmpty() && !focusState) {
                     BasicText(
-                        text = stringResource(R.string.azure_communication_ui_chat_enter_a_message),
+                        text = "",
                         style = TextStyle(
                             color = textColor
                         )

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
@@ -33,6 +33,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import com.azure.android.communication.ui.chat.R
 import com.azure.android.communication.ui.chat.presentation.ui.chat.UITestTags
 import com.azure.android.communication.ui.chat.redux.action.Action
 import com.azure.android.communication.ui.chat.redux.action.ChatAction
@@ -110,7 +112,7 @@ internal fun MessageInput(
 
                 if (textContent.isEmpty() && !focusState) {
                     BasicText(
-                        text = "",
+                        text = stringResource(R.string.azure_communication_ui_chat_enter_a_message),
                         style = TextStyle(
                             color = textColor
                         )

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/SendMessageButtonView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/SendMessageButtonView.kt
@@ -27,19 +27,20 @@ internal fun SendMessageButtonView(
     contentDescription: String,
     modifier: Modifier = Modifier,
     chatStatus: ChatStatus,
+    clickable: Boolean = false,
     onClick: () -> Unit = {},
 ) {
     val semantics = Modifier.semantics {
         this.contentDescription = contentDescription
         this.role = Role.Image
     }
-    val painter = if (chatStatus == ChatStatus.INITIALIZED)
+    val painter = if (chatStatus == ChatStatus.INITIALIZED && clickable)
         painterResource(id = R.drawable.azure_communication_ui_chat_ic_fluent_send_message_button_20_filled_enabled)
     else
         painterResource(id = R.drawable.azure_communication_ui_chat_ic_fluent_send_message_button_20_filled_disabled)
     Box(
         modifier = Modifier.testTag(UITestTags.MESSAGE_SEND_BUTTON).clickable {
-            if (chatStatus == ChatStatus.INITIALIZED) {
+            if (chatStatus == ChatStatus.INITIALIZED && clickable) {
                 onClick()
             }
         }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/UnreadMessagesIndicatorView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/UnreadMessagesIndicatorView.kt
@@ -38,7 +38,8 @@ internal fun UnreadMessagesIndicatorView(
             icon = {
                 Icon(
                     painterResource(id = R.drawable.azure_communication_ui_chat_ic_fluent_arrow_down_16_filled),
-                    modifier = Modifier.height(ChatCompositeTheme.dimensions.unreadMessagesIndicatorIconHeight)
+                    modifier = Modifier
+                        .height(ChatCompositeTheme.dimensions.unreadMessagesIndicatorIconHeight)
                         .padding(ChatCompositeTheme.dimensions.unreadMessagesIndicatorIconPadding),
                     contentDescription = null
                 )
@@ -46,8 +47,13 @@ internal fun UnreadMessagesIndicatorView(
             text = {
                 Text(
                     text = when (unreadCount) {
+                        in Int.MIN_VALUE..0 -> return@ExtendedFloatingActionButton
                         1 -> content.getString(R.string.azure_communication_ui_chat_unread_new_message)
-                        else -> content.getString(R.string.azure_communication_ui_chat_unread_new_messages, unreadCount.toString())
+                        in 2..99 -> content.getString(
+                            R.string.azure_communication_ui_chat_unread_new_messages,
+                            unreadCount.toString()
+                        )
+                        else -> content.getString(R.string.azure_communication_ui_chat_many_unread_new_messages)
                     },
                     fontSize = ChatCompositeTheme.dimensions.unreadMessagesIndicatorTextFontSize
                 )

--- a/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
+++ b/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
@@ -11,6 +11,7 @@
     <string name="azure_communication_ui_chat_others">others</string>
     <string name="azure_communication_ui_chat_unread_new_message">1 new message</string>
     <string name="azure_communication_ui_chat_unread_new_messages">%1$s new messages</string>
+    <string name="azure_communication_ui_chat_many_unread_new_messages">99+ new messages</string>
     <string name="azure_communication_ui_chat_first_name_is_typing">%1$s is typing</string>
     <string name="azure_communication_ui_chat_two_names_are_typing">%1$s and %2$s are typing"</string>
     <string name="azure_communication_ui_chat_three_or_more_are_typing">%1$s, %2$s and %3$d %4$s are typing</string>

--- a/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
+++ b/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
@@ -6,6 +6,7 @@
     <string name="azure_communication_ui_chat_chat_action_bar_title">Chat</string>
     <string name="azure_communication_ui_chat_title_activity_compose_chat">ComposeChatActivity</string>
     <string name="azure_communication_ui_chat_demo_app_title">Chat Composite Demo App</string>
+    <string name="azure_communication_ui_chat_enter_a_message">Type a new message</string>
     <string name="azure_communication_ui_chat_other">other</string>
     <string name="azure_communication_ui_chat_others">others</string>
     <string name="azure_communication_ui_chat_unread_new_message">1 new message</string>

--- a/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
+++ b/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
@@ -6,7 +6,6 @@
     <string name="azure_communication_ui_chat_chat_action_bar_title">Chat</string>
     <string name="azure_communication_ui_chat_title_activity_compose_chat">ComposeChatActivity</string>
     <string name="azure_communication_ui_chat_demo_app_title">Chat Composite Demo App</string>
-    <string name="azure_communication_ui_chat_enter_a_message">Hey, whats up?</string>
     <string name="azure_communication_ui_chat_other">other</string>
     <string name="azure_communication_ui_chat_others">others</string>
     <string name="azure_communication_ui_chat_unread_new_message">1 new message</string>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Cannot send the empty messages
* Delete message input hint 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
