### PR TITLE
[Feature][Chat] Tap and Hold context menu Copy message

### DIFF
--- a/azure-communication-ui/build.gradle
+++ b/azure-communication-ui/build.gradle
@@ -45,6 +45,7 @@ buildscript {
         microsoft_dualscreen_layout_version = '1.0.0-alpha01'
         microsoft_fluent_ui_version = '0.0.21'
         microsoft_fluent_ui_version_v2 = '0.1.2'
+        microsoft_fluent_ui_drawer_version_v2 = '0.1.3'
 
         mockito_inline_version = '4.3.1'
         mockito_kotlin_version = '4.0.0'

--- a/azure-communication-ui/chat/build.gradle
+++ b/azure-communication-ui/chat/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     implementation "com.microsoft.fluentui:fluentui_others:$microsoft_fluent_ui_version_v2"
     implementation "com.microsoft.fluentui:fluentui_persona:$microsoft_fluent_ui_version"
     implementation "com.microsoft.fluentui:fluentui_progress:$microsoft_fluent_ui_version"
+    implementation "com.microsoft.fluentui:fluentui_drawer:$microsoft_fluent_ui_drawer_version_v2"
 
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/MenuItemModel.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/MenuItemModel.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+package com.azure.android.communication.ui.chat.models
+
+import android.content.Context
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import com.azure.android.communication.ui.chat.redux.action.Action
+
+internal data class MenuItemModel(
+    @StringRes val title: Int,
+    @DrawableRes val icon: Int,
+    val action: Action? = null,
+    var onClickAction: ((context: Context) -> Unit)? = null,
+)

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/MessageContextMenuModel.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/models/MessageContextMenuModel.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+package com.azure.android.communication.ui.chat.models
+
+internal data class MessageContextMenuModel(
+    val messageInfoModel: MessageInfoModel,
+    val menuItems: List<MenuItemModel>,
+)

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageContextMenu.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageContextMenu.kt
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.communication.ui.chat.presentation.ui.chat.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.azure.android.communication.ui.chat.R
+import com.azure.android.communication.ui.chat.models.EMPTY_MESSAGE_INFO_MODEL
+import com.azure.android.communication.ui.chat.models.MenuItemModel
+import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
+import com.azure.android.communication.ui.chat.preview.MOCK_MESSAGES
+import com.azure.android.communication.ui.chat.redux.Dispatch
+import com.azure.android.communication.ui.chat.redux.action.ChatAction
+import com.jakewharton.threetenabp.AndroidThreeTen
+import com.microsoft.fluentui.tokenized.drawer.Drawer
+import com.microsoft.fluentui.tokenized.drawer.rememberDrawerState
+import com.microsoft.fluentui.tokenized.listitem.ListItem
+import com.microsoft.fluentui.tokenized.listitem.TextIcons
+import kotlinx.coroutines.launch
+
+@Composable
+internal fun messageContextMenu(
+    menu: MessageContextMenuModel,
+    dispatch: Dispatch,
+) {
+    val lastSelectedItem = remember { mutableStateOf(EMPTY_MESSAGE_INFO_MODEL) }
+    var drawerState = rememberDrawerState()
+    val coroutineScope = rememberCoroutineScope()
+    val currentItem = menu.messageInfoModel
+
+    // When the selected item changes, show/hide menu
+    // When EMPTY_MESSAGE_INFO_MODEL hide()
+    // Otherwise show()
+    if (currentItem.id != lastSelectedItem.value.id) {
+        LaunchedEffect(currentItem) {
+            coroutineScope.launch {
+                if (currentItem == EMPTY_MESSAGE_INFO_MODEL) {
+                    drawerState.close()
+                } else {
+                    drawerState.open()
+                }
+            }
+        }
+    }
+
+    lastSelectedItem.value = currentItem
+
+    Drawer(
+        drawerState = drawerState,
+        scrimVisible = true,
+        expandable = false,
+        drawerContent = {
+            Column {
+                menu.menuItems.map { item ->
+                    val context = LocalContext.current
+                    ListItem.Item(
+                        text = stringResource(id = item.title),
+                        primaryTextLeadingIcons = TextIcons({
+                            Icon(
+                                painter = painterResource(id = item.icon),
+                                contentDescription = null
+                            )
+                        }),
+                        onClick = {
+                            dispatch(ChatAction.HideMessageContextMenu())
+                            if (item.onClickAction != null) {
+                                item.onClickAction?.invoke(context)
+                            } else if (item.action != null) {
+                                dispatch(item.action)
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    )
+}
+
+@Composable
+@Preview
+fun MessageContextMenuPreview() {
+    // Preview Doesn't work
+    // When setting initial drawerState to Open, it is still not visible in preview
+    // May be fluent UI bug
+    AndroidThreeTen.init(LocalContext.current)
+    Box(
+        Modifier
+            .width(300.dp)
+            .height(300.dp)
+            .background(color = androidx.compose.ui.graphics.Color.Blue)
+    ) {
+        messageContextMenu(
+            menu = MessageContextMenuModel(
+                messageInfoModel = MOCK_MESSAGES[0],
+                menuItems = listOf(
+                    MenuItemModel(
+                        title = R.string.azure_communication_ui_chat_copy,
+                        icon = R.drawable.azure_communication_ui_chat_ic_fluent_copy_20_regular,
+                        onClickAction = { }
+                    ),
+                )
+            ),
+            dispatch = {}
+        )
+    }
+}

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageListView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageListView.kt
@@ -53,7 +53,7 @@ internal fun MessageListView(
         reverseLayout = true,
     ) {
         itemsIndexed(messages.asReversed(), key = { index, item -> item.message.id ?: index }) { index, message ->
-            MessageView(message)
+            MessageView(message, dispatchers)
         }
         if (messages.isNotEmpty() && showLoading) {
             item {

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageView.kt
@@ -6,7 +6,6 @@ package com.azure.android.communication.ui.chat.presentation.ui.chat.components
 import android.widget.TextView
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,7 +32,6 @@ import com.azure.android.communication.ui.chat.presentation.ui.viewmodel.toViewM
 import com.azure.android.communication.ui.chat.preview.MOCK_LOCAL_USER_ID
 import com.azure.android.communication.ui.chat.preview.MOCK_MESSAGES
 import com.azure.android.communication.ui.chat.redux.Dispatch
-import com.azure.android.communication.ui.chat.redux.action.ChatAction
 import com.azure.android.communication.ui.chat.service.sdk.wrapper.ChatMessageType
 import com.jakewharton.threetenabp.AndroidThreeTen
 import com.microsoft.fluentui.persona.AvatarSize
@@ -138,9 +136,11 @@ private fun BasicChatMessage(viewModel: MessageViewModel, dispatch: Dispatch) {
                         },
                         shape = ChatCompositeTheme.shapes.messageBubble,
                     ).align(alignment = if (viewModel.isLocalUser) Alignment.TopEnd else Alignment.TopStart)
-                        .combinedClickable(onLongClick = {
-                            dispatch(ChatAction.ShowMessageContextMenu(viewModel.message))
-                        }, onClick = {})
+                    /* TODO: Add this block back in to add Context Menu Code
+                    .combinedClickable(onLongClick = {
+                        dispatch(ChatAction.ShowMessageContextMenu(viewModel.message))
+                    }, onClick = {})
+                    */
                 ) {
                     messageContent(viewModel)
                 }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageView.kt
@@ -4,7 +4,9 @@
 package com.azure.android.communication.ui.chat.presentation.ui.chat.components
 
 import android.widget.TextView
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -30,6 +32,8 @@ import com.azure.android.communication.ui.chat.presentation.ui.viewmodel.Message
 import com.azure.android.communication.ui.chat.presentation.ui.viewmodel.toViewModelList
 import com.azure.android.communication.ui.chat.preview.MOCK_LOCAL_USER_ID
 import com.azure.android.communication.ui.chat.preview.MOCK_MESSAGES
+import com.azure.android.communication.ui.chat.redux.Dispatch
+import com.azure.android.communication.ui.chat.redux.action.ChatAction
 import com.azure.android.communication.ui.chat.service.sdk.wrapper.ChatMessageType
 import com.jakewharton.threetenabp.AndroidThreeTen
 import com.microsoft.fluentui.persona.AvatarSize
@@ -39,7 +43,7 @@ import org.threeten.bp.format.DateTimeFormatter
 val timeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("h:mm a")
 
 @Composable
-internal fun MessageView(viewModel: MessageViewModel) {
+internal fun MessageView(viewModel: MessageViewModel, dispatch: Dispatch) {
 
     Column(
         modifier = Modifier.padding(ChatCompositeTheme.dimensions.messageOuterPadding),
@@ -62,8 +66,8 @@ internal fun MessageView(viewModel: MessageViewModel) {
             }
         }
         when (viewModel.message.messageType) {
-            ChatMessageType.TEXT -> BasicChatMessage(viewModel)
-            ChatMessageType.HTML -> BasicChatMessage(viewModel)
+            ChatMessageType.TEXT -> BasicChatMessage(viewModel, dispatch)
+            ChatMessageType.HTML -> BasicChatMessage(viewModel, dispatch)
             ChatMessageType.TOPIC_UPDATED -> SystemMessage(
                 icon = R.drawable.azure_communication_ui_chat_ic_topic_changed_filled, /* TODO: update icon */
                 stringResource = R.string.azure_communication_ui_chat_topic_updated,
@@ -106,8 +110,9 @@ private fun SystemMessage(icon: Int, stringResource: Int, substitution: List<Str
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun BasicChatMessage(viewModel: MessageViewModel) {
+private fun BasicChatMessage(viewModel: MessageViewModel, dispatch: Dispatch) {
     Box(modifier = Modifier.fillMaxWidth()) {
         Row(modifier = Modifier.align(alignment = if (viewModel.isLocalUser) Alignment.TopEnd else Alignment.TopStart)) {
             // Avatar Rail (Left Padding)
@@ -133,6 +138,9 @@ private fun BasicChatMessage(viewModel: MessageViewModel) {
                         },
                         shape = ChatCompositeTheme.shapes.messageBubble,
                     ).align(alignment = if (viewModel.isLocalUser) Alignment.TopEnd else Alignment.TopStart)
+                        .combinedClickable(onLongClick = {
+                            dispatch(ChatAction.ShowMessageContextMenu(viewModel.message))
+                        }, onClick = {})
                 ) {
                     messageContent(viewModel)
                 }
@@ -224,7 +232,7 @@ internal fun PreviewChatCompositeMessage() {
             OffsetDateTime.now()
         )
         for (a in 0 until vms.size) {
-            MessageView(vms[a])
+            MessageView(vms[a]) { }
         }
     }
 }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/ChatScreen.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/ChatScreen.kt
@@ -11,20 +11,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.BasicText
-import androidx.compose.material.Icon
 import androidx.compose.material.Scaffold
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.azure.android.communication.ui.chat.R
+import com.azure.android.communication.ui.chat.models.EMPTY_MESSAGE_INFO_MODEL
 import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
 import com.azure.android.communication.ui.chat.models.RemoteParticipantInfoModel
 import com.azure.android.communication.ui.chat.presentation.style.ChatCompositeTheme
@@ -35,21 +33,15 @@ import com.azure.android.communication.ui.chat.presentation.ui.chat.components.F
 import com.azure.android.communication.ui.chat.presentation.ui.chat.components.MessageListView
 import com.azure.android.communication.ui.chat.presentation.ui.chat.components.TypingIndicatorView
 import com.azure.android.communication.ui.chat.presentation.ui.chat.components.UnreadMessagesIndicatorView
+import com.azure.android.communication.ui.chat.presentation.ui.chat.components.messageContextMenu
 import com.azure.android.communication.ui.chat.presentation.ui.viewmodel.ChatScreenViewModel
 import com.azure.android.communication.ui.chat.presentation.ui.viewmodel.toViewModelList
 import com.azure.android.communication.ui.chat.preview.MOCK_LOCAL_USER_ID
 import com.azure.android.communication.ui.chat.preview.MOCK_MESSAGES
-import com.azure.android.communication.ui.chat.redux.Dispatch
-import com.azure.android.communication.ui.chat.redux.action.ChatAction
 import com.azure.android.communication.ui.chat.redux.action.NavigationAction
 import com.azure.android.communication.ui.chat.redux.state.ChatStatus
 import com.azure.android.communication.ui.chat.service.sdk.wrapper.CommunicationIdentifier
 import com.jakewharton.threetenabp.AndroidThreeTen
-import com.microsoft.fluentui.tokenized.drawer.Drawer
-import com.microsoft.fluentui.tokenized.drawer.rememberDrawerState
-import com.microsoft.fluentui.tokenized.listitem.ListItem
-import com.microsoft.fluentui.tokenized.listitem.TextIcons
-import kotlinx.coroutines.launch
 
 @Composable
 internal fun ChatScreen(
@@ -124,14 +116,15 @@ internal fun ChatScreen(
                         )
                     }
                 }
-                if (viewModel.messageContextMenu != null) {
-                    showMessageContextMenu(viewModel.messageContextMenu, dispatch = viewModel.postAction)
-                }
             }
         },
         bottomBar = {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Box(modifier = Modifier.align(alignment = Alignment.Start).padding(horizontal = 5.dp)) {
+                Box(
+                    modifier = Modifier
+                        .align(alignment = Alignment.Start)
+                        .padding(horizontal = 5.dp)
+                ) {
                     TypingIndicatorView(viewModel.typingParticipants.toList())
                 }
 
@@ -143,39 +136,12 @@ internal fun ChatScreen(
             }
         }
     )
-}
-@Composable
-internal fun showMessageContextMenu(menu: MessageContextMenuModel, dispatch: Dispatch) {
-    val scope = rememberCoroutineScope()
-    val drawerState = rememberDrawerState()
-    val open: () -> Unit = { scope.launch { drawerState.open() } }
-    val close: () -> Unit = { scope.launch { drawerState.close() } }
-    Drawer(drawerState = drawerState, drawerContent = {
-        Column() {
-            menu.menuItems.map { item ->
-                val context = LocalContext.current
-                ListItem.Item(
-                    text = stringResource(id = item.title),
-                    primaryTextLeadingIcons = TextIcons({
-                        Icon(
-                            painter = painterResource(id = item.icon),
-                            contentDescription = null
-                        )
-                    }),
-                    onClick = {
-                        close()
-                        dispatch(ChatAction.HideMessageContextMenu())
-                        if (item.onClickAction != null) {
-                            item.onClickAction?.invoke(context)
-                        } else if (item.action != null) {
-                            dispatch(item.action)
-                        }
-                    }
-                )
-            }
-        }
-    })
-    open()
+
+    /* TODO: Add this Composable back in to support Context Menu (Copy)
+    messageContextMenu(
+        menu = viewModel.messageContextMenu,
+        dispatch = viewModel.postAction,)
+     */
 }
 
 @Preview
@@ -212,11 +178,11 @@ internal fun ChatScreenPreview() {
                         CommunicationIdentifier.UnknownIdentifier("DB75F1F0-65E4-46B0-A213-DA4F574659A5"),
                         "Henry Jones"
                     ),
-                ).associateBy({ it.userIdentifier.id })
-
-                // error = ChatStateError(
-                //    errorCode = ErrorCode.CHAT_JOIN_FAILED
-                // )
+                ).associateBy { it.userIdentifier.id },
+                messageContextMenu = MessageContextMenuModel(
+                    messageInfoModel = EMPTY_MESSAGE_INFO_MODEL,
+                    menuItems = emptyList()
+                )
             ),
 
         )

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/NavigatableBaseScreen.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/NavigatableBaseScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.azure.android.communication.ui.chat.models.EMPTY_MESSAGE_INFO_MODEL
+import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
 import com.azure.android.communication.ui.chat.models.RemoteParticipantInfoModel
 import com.azure.android.communication.ui.chat.presentation.style.ChatCompositeTheme
 import com.azure.android.communication.ui.chat.presentation.ui.chat.ChatScreenStateViewModel
@@ -98,7 +100,8 @@ internal fun NavigatableBaseScreenPreview() {
                         CommunicationIdentifier.UnknownIdentifier("DB75F1F0-65E4-46B0-A213-DA4F574659A5"),
                         "Henry Jones"
                     ),
-                ).associateBy({ it.userIdentifier.id })
+                ).associateBy { it.userIdentifier.id },
+                messageContextMenu = MessageContextMenuModel(messageInfoModel = EMPTY_MESSAGE_INFO_MODEL, menuItems = emptyList()),
 
                 // error = ChatStateError(
                 //    errorCode = ErrorCode.CHAT_JOIN_FAILED

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/NavigatableBaseScreen.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/NavigatableBaseScreen.kt
@@ -5,6 +5,13 @@ package com.azure.android.communication.ui.chat.presentation.ui.chat.screens
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -43,7 +50,13 @@ internal fun NavigatableBaseScreen(
     ) {
         ChatScreen(viewModel = viewModel, stateViewModel = stateViewModel)
 
-        AnimatedVisibility(visible = viewModel.navigationStatus == NavigationStatus.PARTICIPANTS) {
+        AnimatedVisibility(
+            visible = viewModel.navigationStatus == NavigationStatus.PARTICIPANTS,
+            enter = slideInHorizontally(animationSpec = tween(durationMillis = 200)) { fullWidth -> fullWidth / 3 } +
+                fadeIn(animationSpec = tween(durationMillis = 200)),
+            exit = slideOutHorizontally(animationSpec = spring(stiffness = Spring.StiffnessHigh)) { 200 } +
+                fadeOut(animationSpec = tween(durationMillis = 200))
+        ) {
             ParticipantScreen(viewModel = viewModel)
         }
     }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/ParticipantScreen.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/ParticipantScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.azure.android.communication.ui.chat.R
+import com.azure.android.communication.ui.chat.models.EMPTY_MESSAGE_INFO_MODEL
+import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
 import com.azure.android.communication.ui.chat.models.RemoteParticipantInfoModel
 import com.azure.android.communication.ui.chat.presentation.style.ChatCompositeTheme
 import com.azure.android.communication.ui.chat.presentation.ui.chat.components.ActionBarView
@@ -92,11 +94,8 @@ internal fun ParticipantScreenPreview() {
                         CommunicationIdentifier.UnknownIdentifier("DB75F1F0-65E4-46B0-A213-DA4F574659A5"),
                         "Henry Jones"
                     ),
-                ).associateBy({ it.userIdentifier.id })
-
-                // error = ChatStateError(
-                //    errorCode = ErrorCode.CHAT_JOIN_FAILED
-                // )
+                ).associateBy { it.userIdentifier.id },
+                messageContextMenu = MessageContextMenuModel(messageInfoModel = EMPTY_MESSAGE_INFO_MODEL, menuItems = emptyList()),
             ),
 
         )

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/ChatScreenViewModel.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/ChatScreenViewModel.kt
@@ -5,6 +5,7 @@ package com.azure.android.communication.ui.chat.presentation.ui.viewmodel
 
 import android.content.Context
 import com.azure.android.communication.ui.chat.error.ChatStateError
+import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
 import com.azure.android.communication.ui.chat.models.MessageInfoModel
 import com.azure.android.communication.ui.chat.models.RemoteParticipantInfoModel
 import com.azure.android.communication.ui.chat.redux.AppStore
@@ -28,6 +29,7 @@ internal data class ChatScreenViewModel(
     val participants: Map<String, RemoteParticipantInfoModel>,
     val chatTopic: String? = null,
     val navigationStatus: NavigationStatus = NavigationStatus.NONE,
+    val messageContextMenu: MessageContextMenuModel? = null,
 ) {
     val showError get() = error != null
     val errorMessage get() = error?.errorCode?.toString() ?: ""
@@ -59,6 +61,7 @@ internal fun buildChatScreenViewModel(
         participants = store.getCurrentState().participantState.participants,
         chatTopic = store.getCurrentState().chatState.chatInfoModel.topic,
         navigationStatus = store.getCurrentState().navigationState.navigationStatus,
+        messageContextMenu = store.getCurrentState().chatState.messageContextMenu,
     )
 }
 

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/ChatScreenViewModel.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/ChatScreenViewModel.kt
@@ -5,6 +5,7 @@ package com.azure.android.communication.ui.chat.presentation.ui.viewmodel
 
 import android.content.Context
 import com.azure.android.communication.ui.chat.error.ChatStateError
+import com.azure.android.communication.ui.chat.models.EMPTY_MESSAGE_INFO_MODEL
 import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
 import com.azure.android.communication.ui.chat.models.MessageInfoModel
 import com.azure.android.communication.ui.chat.models.RemoteParticipantInfoModel
@@ -29,7 +30,7 @@ internal data class ChatScreenViewModel(
     val participants: Map<String, RemoteParticipantInfoModel>,
     val chatTopic: String? = null,
     val navigationStatus: NavigationStatus = NavigationStatus.NONE,
-    val messageContextMenu: MessageContextMenuModel? = null,
+    val messageContextMenu: MessageContextMenuModel,
 ) {
     val showError get() = error != null
     val errorMessage get() = error?.errorCode?.toString() ?: ""
@@ -61,7 +62,7 @@ internal fun buildChatScreenViewModel(
         participants = store.getCurrentState().participantState.participants,
         chatTopic = store.getCurrentState().chatState.chatInfoModel.topic,
         navigationStatus = store.getCurrentState().navigationState.navigationStatus,
-        messageContextMenu = store.getCurrentState().chatState.messageContextMenu,
+        messageContextMenu = store.getCurrentState().chatState.messageContextMenu ?: MessageContextMenuModel(messageInfoModel = EMPTY_MESSAGE_INFO_MODEL, emptyList()),
     )
 }
 

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/action/ChatAction.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/action/ChatAction.kt
@@ -24,4 +24,7 @@ internal sealed class ChatAction : Action {
     class MessageEdited(val message: MessageInfoModel) : ChatAction()
     class MessageRead(val messageId: String) : ChatAction()
     class TypingIndicator : ChatAction()
+    class ShowMessageContextMenu(val message: MessageInfoModel) : ChatAction()
+    class HideMessageContextMenu : ChatAction()
+    class CopyMessageText(val message: MessageInfoModel) : ChatAction()
 }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/ChatReducer.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/ChatReducer.kt
@@ -3,6 +3,11 @@
 
 package com.azure.android.communication.ui.chat.redux.reducer
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import com.azure.android.communication.ui.chat.R
+import com.azure.android.communication.ui.chat.models.MenuItemModel
+import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
 import com.azure.android.communication.ui.chat.redux.action.Action
 import com.azure.android.communication.ui.chat.redux.action.ChatAction
 import com.azure.android.communication.ui.chat.redux.state.ChatState
@@ -36,6 +41,26 @@ internal class ChatReducerImpl : ChatReducer {
                     lastReadMessageId = if (state.lastReadMessageId> action.messageId) state.lastReadMessageId
                     else action.messageId
                 )
+            }
+            is ChatAction.ShowMessageContextMenu -> {
+                state.copy(
+                    messageContextMenu = MessageContextMenuModel(
+                        messageInfoModel = action.message,
+                        menuItems = listOf(
+                            MenuItemModel(
+                                R.string.azure_communication_ui_chat_copy,
+                                R.drawable.azure_communication_ui_chat_ic_fluent_copy_20_regular,
+                                onClickAction = { context ->
+                                    val clipboardManager = context.getSystemService(ClipboardManager::class.java)
+                                    clipboardManager.setPrimaryClip(ClipData.newPlainText(context.getString(R.string.azure_communication_ui_chat_message), action.message.content))
+                                }
+                            ),
+                        )
+                    )
+                )
+            }
+            is ChatAction.HideMessageContextMenu -> {
+                state.copy(messageContextMenu = null)
             }
             else -> state
         }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/ChatReducer.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/ChatReducer.kt
@@ -6,6 +6,7 @@ package com.azure.android.communication.ui.chat.redux.reducer
 import android.content.ClipData
 import android.content.ClipboardManager
 import com.azure.android.communication.ui.chat.R
+import com.azure.android.communication.ui.chat.models.EMPTY_MESSAGE_INFO_MODEL
 import com.azure.android.communication.ui.chat.models.MenuItemModel
 import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
 import com.azure.android.communication.ui.chat.redux.action.Action
@@ -60,7 +61,9 @@ internal class ChatReducerImpl : ChatReducer {
                 )
             }
             is ChatAction.HideMessageContextMenu -> {
-                state.copy(messageContextMenu = null)
+                state.copy(
+                    messageContextMenu = MessageContextMenuModel(messageInfoModel = EMPTY_MESSAGE_INFO_MODEL, menuItems = emptyList())
+                )
             }
             else -> state
         }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/AppReduxState.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/AppReduxState.kt
@@ -4,7 +4,9 @@
 package com.azure.android.communication.ui.chat.redux.state
 
 import com.azure.android.communication.ui.chat.models.ChatInfoModel
+import com.azure.android.communication.ui.chat.models.EMPTY_MESSAGE_INFO_MODEL
 import com.azure.android.communication.ui.chat.models.LocalParticipantInfoModel
+import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
 import org.threeten.bp.OffsetDateTime
 
 internal class AppReduxState(
@@ -26,6 +28,7 @@ internal class AppReduxState(
         ),
         lastReadMessageId = "",
         lastSendMessageId = "",
+        messageContextMenu = MessageContextMenuModel(EMPTY_MESSAGE_INFO_MODEL, emptyList())
     )
 
     override var participantState: ParticipantsState = ParticipantsState(

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/ChatState.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/ChatState.kt
@@ -21,5 +21,5 @@ internal data class ChatState(
     val chatInfoModel: ChatInfoModel,
     val lastReadMessageId: String,
     val lastSendMessageId: String,
-    val messageContextMenu: MessageContextMenuModel? = null,
+    val messageContextMenu: MessageContextMenuModel,
 )

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/ChatState.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/ChatState.kt
@@ -5,6 +5,7 @@ package com.azure.android.communication.ui.chat.redux.state
 
 import com.azure.android.communication.ui.chat.models.ChatInfoModel
 import com.azure.android.communication.ui.chat.models.LocalParticipantInfoModel
+import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
 
 // ChatStatus will help to subscribe to real tim notifications when state is initialized
 // The foreground/background mode for activity can query as per state here
@@ -20,4 +21,5 @@ internal data class ChatState(
     val chatInfoModel: ChatInfoModel,
     val lastReadMessageId: String,
     val lastSendMessageId: String,
+    val messageContextMenu: MessageContextMenuModel? = null,
 )

--- a/azure-communication-ui/chat/src/main/res/drawable/azure_communication_ui_chat_ic_fluent_copy_20_regular.xml
+++ b/azure-communication-ui/chat/src/main/res/drawable/azure_communication_ui_chat_ic_fluent_copy_20_regular.xml
@@ -1,0 +1,3 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="20dp" android:height="20dp" android:viewportWidth="20" android:viewportHeight="20">
+    <path android:pathData="M8 2C6.895 2 6 2.895 6 4v10c0 1.105 0.895 2 2 2h6c1.105 0 2-0.895 2-2V4c0-1.105-0.895-2-2-2H8zM7 4c0-0.552 0.448-1 1-1h6c0.552 0 1 0.448 1 1v10c0 0.552-0.448 1-1 1H8c-0.552 0-1-0.448-1-1V4zM4 6c0-0.74 0.402-1.387 1-1.732V14.5C5 15.88 6.12 17 7.5 17h6.232c-0.345 0.598-0.992 1-1.732 1H7.5C5.567 18 4 16.433 4 14.5V6z" android:fillColor="#212121"/>
+</vector>

--- a/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
+++ b/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
@@ -26,4 +26,6 @@
     <string name="azure_communication_ui_chat_in_this_chat_count">In this chat (%1$d)</string>
     <string name="azure_communication_ui_chat_people">People</string>
     <string name="azure_communication_ui_chat_count_people">%1$d people</string>
+    <string name="azure_communication_ui_chat_copy">Copy</string>
+    <string name="azure_communication_ui_chat_message">Message</string>
 </resources>

--- a/azure-communication-ui/chat/src/test/java/com/azure/android/communication/ui/chat/redux/reducer/ChatReducerUnitTest.kt
+++ b/azure-communication-ui/chat/src/test/java/com/azure/android/communication/ui/chat/redux/reducer/ChatReducerUnitTest.kt
@@ -4,7 +4,9 @@
 package com.azure.android.communication.ui.chat.redux.reducer
 
 import com.azure.android.communication.ui.chat.models.ChatInfoModel
+import com.azure.android.communication.ui.chat.models.EMPTY_MESSAGE_INFO_MODEL
 import com.azure.android.communication.ui.chat.models.LocalParticipantInfoModel
+import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
 import com.azure.android.communication.ui.chat.redux.action.ChatAction
 import com.azure.android.communication.ui.chat.redux.state.ChatState
 import com.azure.android.communication.ui.chat.redux.state.ChatStatus
@@ -23,7 +25,9 @@ internal class ChatReducerUnitTest {
         val localParticipantInfoModel = mock<LocalParticipantInfoModel> { }
         val chatInfoModel = mock<ChatInfoModel>()
         val previousState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "")
+            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
+                EMPTY_MESSAGE_INFO_MODEL, emptyList()
+            ))
         val action = ChatAction.Initialization()
 
         // act
@@ -40,7 +44,9 @@ internal class ChatReducerUnitTest {
         val localParticipantInfoModel = mock<LocalParticipantInfoModel> { }
         val chatInfoModel = mock<ChatInfoModel>()
         val previousState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "")
+            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
+                EMPTY_MESSAGE_INFO_MODEL, emptyList()
+            ))
         val action = ChatAction.Initialized()
 
         // act
@@ -57,11 +63,15 @@ internal class ChatReducerUnitTest {
         val localParticipantInfoModel = mock<LocalParticipantInfoModel> { }
         val chatInfoModel = ChatInfoModel(threadId = "", topic = "Previous Chat topic")
         val previousState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "")
+            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
+                EMPTY_MESSAGE_INFO_MODEL, emptyList()
+            ))
         val action = ChatAction.TopicUpdated("New Chat topic")
         val afterChatInfoModel = ChatInfoModel(threadId = "", topic = "New Chat topic")
         val afterState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, afterChatInfoModel, "", "")
+            ChatState(ChatStatus.NONE, localParticipantInfoModel, afterChatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
+                EMPTY_MESSAGE_INFO_MODEL, emptyList()
+            ))
 
         // act
         val newState = reducer.reduce(previousState, action)
@@ -77,11 +87,15 @@ internal class ChatReducerUnitTest {
         val localParticipantInfoModel = mock<LocalParticipantInfoModel> { }
         val chatInfoModel = ChatInfoModel(threadId = "", topic = "", allMessagesFetched = false)
         val previousState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "")
+            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
+                EMPTY_MESSAGE_INFO_MODEL, emptyList()
+            ))
         val action = ChatAction.AllMessagesFetched()
         val afterChatInfoModel = ChatInfoModel(threadId = "", topic = "", allMessagesFetched = true)
         val afterState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, afterChatInfoModel, "", "")
+            ChatState(ChatStatus.NONE, localParticipantInfoModel, afterChatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
+                EMPTY_MESSAGE_INFO_MODEL, emptyList()
+            ))
 
         // act
         val newState = reducer.reduce(previousState, action)
@@ -103,7 +117,9 @@ internal class ChatReducerUnitTest {
             isThreadDeleted = false
         )
         val previousState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "")
+            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
+                EMPTY_MESSAGE_INFO_MODEL, emptyList()
+            ))
 
         val action = ChatAction.ThreadDeleted()
 
@@ -114,7 +130,9 @@ internal class ChatReducerUnitTest {
             isThreadDeleted = true
         )
         val afterState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, afterChatInfoModel, "", "")
+            ChatState(ChatStatus.NONE, localParticipantInfoModel, afterChatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
+                EMPTY_MESSAGE_INFO_MODEL, emptyList()
+            ))
 
         // act
         val newState = reducer.reduce(previousState, action)

--- a/azure-communication-ui/chat/src/test/java/com/azure/android/communication/ui/chat/redux/reducer/ChatReducerUnitTest.kt
+++ b/azure-communication-ui/chat/src/test/java/com/azure/android/communication/ui/chat/redux/reducer/ChatReducerUnitTest.kt
@@ -25,9 +25,12 @@ internal class ChatReducerUnitTest {
         val localParticipantInfoModel = mock<LocalParticipantInfoModel> { }
         val chatInfoModel = mock<ChatInfoModel>()
         val previousState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
-                EMPTY_MESSAGE_INFO_MODEL, emptyList()
-            ))
+            ChatState(
+                ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "",
+                messageContextMenu = MessageContextMenuModel(
+                    EMPTY_MESSAGE_INFO_MODEL, emptyList()
+                )
+            )
         val action = ChatAction.Initialization()
 
         // act
@@ -44,9 +47,12 @@ internal class ChatReducerUnitTest {
         val localParticipantInfoModel = mock<LocalParticipantInfoModel> { }
         val chatInfoModel = mock<ChatInfoModel>()
         val previousState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
-                EMPTY_MESSAGE_INFO_MODEL, emptyList()
-            ))
+            ChatState(
+                ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "",
+                messageContextMenu = MessageContextMenuModel(
+                    EMPTY_MESSAGE_INFO_MODEL, emptyList()
+                )
+            )
         val action = ChatAction.Initialized()
 
         // act
@@ -63,15 +69,21 @@ internal class ChatReducerUnitTest {
         val localParticipantInfoModel = mock<LocalParticipantInfoModel> { }
         val chatInfoModel = ChatInfoModel(threadId = "", topic = "Previous Chat topic")
         val previousState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
-                EMPTY_MESSAGE_INFO_MODEL, emptyList()
-            ))
+            ChatState(
+                ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "",
+                messageContextMenu = MessageContextMenuModel(
+                    EMPTY_MESSAGE_INFO_MODEL, emptyList()
+                )
+            )
         val action = ChatAction.TopicUpdated("New Chat topic")
         val afterChatInfoModel = ChatInfoModel(threadId = "", topic = "New Chat topic")
         val afterState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, afterChatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
-                EMPTY_MESSAGE_INFO_MODEL, emptyList()
-            ))
+            ChatState(
+                ChatStatus.NONE, localParticipantInfoModel, afterChatInfoModel, "", "",
+                messageContextMenu = MessageContextMenuModel(
+                    EMPTY_MESSAGE_INFO_MODEL, emptyList()
+                )
+            )
 
         // act
         val newState = reducer.reduce(previousState, action)
@@ -87,15 +99,21 @@ internal class ChatReducerUnitTest {
         val localParticipantInfoModel = mock<LocalParticipantInfoModel> { }
         val chatInfoModel = ChatInfoModel(threadId = "", topic = "", allMessagesFetched = false)
         val previousState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
-                EMPTY_MESSAGE_INFO_MODEL, emptyList()
-            ))
+            ChatState(
+                ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "",
+                messageContextMenu = MessageContextMenuModel(
+                    EMPTY_MESSAGE_INFO_MODEL, emptyList()
+                )
+            )
         val action = ChatAction.AllMessagesFetched()
         val afterChatInfoModel = ChatInfoModel(threadId = "", topic = "", allMessagesFetched = true)
         val afterState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, afterChatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
-                EMPTY_MESSAGE_INFO_MODEL, emptyList()
-            ))
+            ChatState(
+                ChatStatus.NONE, localParticipantInfoModel, afterChatInfoModel, "", "",
+                messageContextMenu = MessageContextMenuModel(
+                    EMPTY_MESSAGE_INFO_MODEL, emptyList()
+                )
+            )
 
         // act
         val newState = reducer.reduce(previousState, action)
@@ -117,9 +135,12 @@ internal class ChatReducerUnitTest {
             isThreadDeleted = false
         )
         val previousState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
-                EMPTY_MESSAGE_INFO_MODEL, emptyList()
-            ))
+            ChatState(
+                ChatStatus.NONE, localParticipantInfoModel, chatInfoModel, "", "",
+                messageContextMenu = MessageContextMenuModel(
+                    EMPTY_MESSAGE_INFO_MODEL, emptyList()
+                )
+            )
 
         val action = ChatAction.ThreadDeleted()
 
@@ -130,9 +151,12 @@ internal class ChatReducerUnitTest {
             isThreadDeleted = true
         )
         val afterState =
-            ChatState(ChatStatus.NONE, localParticipantInfoModel, afterChatInfoModel, "", "", messageContextMenu = MessageContextMenuModel(
-                EMPTY_MESSAGE_INFO_MODEL, emptyList()
-            ))
+            ChatState(
+                ChatStatus.NONE, localParticipantInfoModel, afterChatInfoModel, "", "",
+                messageContextMenu = MessageContextMenuModel(
+                    EMPTY_MESSAGE_INFO_MODEL, emptyList()
+                )
+            )
 
         // act
         val newState = reducer.reduce(previousState, action)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Adds context menu feature for chat messages with a tap-and-hold gesture
* Adds copy action for message context menu

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Join a chat thread and tap-and-hold on a message
* Choose the Copy action from the context menu that appears


## What to Check
Verify that the following are valid
* Clipboard should contain the text content of the message

## Screenshots
![Screenshot_1668032067](https://user-images.githubusercontent.com/43901/200953871-7e01c649-f660-4e24-960f-d03823428420.png)
