### PR TITLE
[Calling][TV][Refactor] fix remote video stream to fit for single remote participant

### DIFF
--- a/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/mocking/TestVideoStreamRendererFactory.kt
+++ b/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/mocking/TestVideoStreamRendererFactory.kt
@@ -10,6 +10,7 @@ import android.widget.FrameLayout
 import com.azure.android.communication.calling.CameraFacing
 import com.azure.android.communication.calling.CreateViewOptions
 import com.azure.android.communication.calling.MediaStreamType
+import com.azure.android.communication.calling.ScalingMode
 import com.azure.android.communication.ui.calling.presentation.VideoStreamRendererFactory
 import com.azure.android.communication.ui.calling.service.sdk.RemoteVideoStream
 import com.azure.android.communication.ui.calling.service.sdk.VideoStreamRenderer
@@ -131,6 +132,9 @@ internal class TestVideoStreamRendererView(context: Context, videoType: VideoTyp
 
     override fun getView(): View {
         return v
+    }
+
+    override fun updateScalingMode(scalingMode: ScalingMode) {
     }
 
     fun switchVideoType(newVideoType: VideoType) {

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/ParticipantGridView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/ParticipantGridView.kt
@@ -171,6 +171,7 @@ internal class ParticipantGridView : GridLayout {
     private fun updateGrid(
         displayedRemoteParticipantsViewModel: List<ParticipantGridCellViewModel>,
     ) {
+        videoViewManager.updateScalingForRemoteStream()
         removeAllViews()
         displayedRemoteParticipantsView = mutableListOf()
         displayedRemoteParticipantsViewModel.forEach {

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDK.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDK.kt
@@ -11,6 +11,7 @@ import com.azure.android.communication.calling.MediaStreamType
 import com.azure.android.communication.calling.CameraFacing
 import com.azure.android.communication.calling.VideoDeviceType
 import com.azure.android.communication.calling.CreateViewOptions
+import com.azure.android.communication.calling.ScalingMode
 import com.azure.android.communication.ui.calling.models.ParticipantInfoModel
 import com.azure.android.communication.ui.calling.redux.state.AudioState
 import com.azure.android.communication.ui.calling.redux.state.CameraDeviceSelectionStatus
@@ -107,6 +108,7 @@ internal interface VideoStreamRenderer {
 internal interface VideoStreamRendererView {
     fun dispose()
     fun getView(): View?
+    fun updateScalingMode(scalingMode: ScalingMode)
 }
 
 internal data class StreamSize(val width: Int, val height: Int)

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/service/sdk/VideoStreamRendererViewWrapper.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/service/sdk/VideoStreamRendererViewWrapper.kt
@@ -4,6 +4,7 @@
 package com.azure.android.communication.ui.calling.service.sdk
 
 import android.view.View
+import com.azure.android.communication.calling.ScalingMode
 
 internal class VideoStreamRendererViewWrapper(private val view: com.azure.android.communication.calling.VideoStreamRendererView) :
     VideoStreamRendererView {
@@ -12,4 +13,5 @@ internal class VideoStreamRendererViewWrapper(private val view: com.azure.androi
     }
 
     override fun getView(): View? = view
+    override fun updateScalingMode(scalingMode: ScalingMode) = view.updateScalingMode(scalingMode)
 }

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/presentation/VideoViewManagerUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/presentation/VideoViewManagerUnitTest.kt
@@ -51,7 +51,14 @@ internal class VideoViewManagerUnitTest {
             on { getLocalVideoStream() } doAnswer { localVideoStreamCompletableFuture }
         }
 
-        val mockContext = mock<Context> {}
+        val mockUiModeManager = mock<android.app.UiModeManager> {
+            on { currentModeType } doAnswer { android.content.res.Configuration.UI_MODE_TYPE_WATCH }
+        }
+
+        val mockContext = mock<Context> {
+            on { getSystemService(Context.UI_MODE_SERVICE) } doAnswer { mockUiModeManager }
+        }
+
         val mockLayout = mock<FrameLayout> {}
 
         val mockVideoStreamRendererView = mock<VideoStreamRendererView> {
@@ -112,7 +119,13 @@ internal class VideoViewManagerUnitTest {
             on { getLocalVideoStream() } doAnswer { localVideoStreamCompletableFuture }
         }
 
-        val mockContext = mock<Context> {}
+        val mockUiModeManager = mock<android.app.UiModeManager> {
+            on { currentModeType } doAnswer { android.content.res.Configuration.UI_MODE_TYPE_WATCH }
+        }
+
+        val mockContext = mock<Context> {
+            on { getSystemService(Context.UI_MODE_SERVICE) } doAnswer { mockUiModeManager }
+        }
 
         val mockLayout = mock<FrameLayout> {}
 
@@ -162,7 +175,13 @@ internal class VideoViewManagerUnitTest {
             on { getRemoteParticipantsMap() } doAnswer { remoteParticipantMap }
         }
 
-        val mockContext = mock<Context> {}
+        val mockUiModeManager = mock<android.app.UiModeManager> {
+            on { currentModeType } doAnswer { android.content.res.Configuration.UI_MODE_TYPE_WATCH }
+        }
+
+        val mockContext = mock<Context> {
+            on { getSystemService(Context.UI_MODE_SERVICE) } doAnswer { mockUiModeManager }
+        }
 
         val mockLayout = mock<FrameLayout> {}
 
@@ -206,7 +225,13 @@ internal class VideoViewManagerUnitTest {
             on { getRemoteParticipantsMap() } doAnswer { remoteParticipantMap }
         }
 
-        val mockContext = mock<Context> {}
+        val mockUiModeManager = mock<android.app.UiModeManager> {
+            on { currentModeType } doAnswer { android.content.res.Configuration.UI_MODE_TYPE_WATCH }
+        }
+
+        val mockContext = mock<Context> {
+            on { getSystemService(Context.UI_MODE_SERVICE) } doAnswer { mockUiModeManager }
+        }
 
         val mockVideoStreamRendererHelper = mock<VideoStreamRendererFactory> {}
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* fix remote video stream to fit for single remote participant
<img width="1138" alt="Screenshot 2022-11-09 at 8 02 37 PM" src="https://user-images.githubusercontent.com/73618019/201004832-cdbca025-2cf3-41b7-86d0-ddc3abc01f5c.png">
<img width="1132" alt="Screenshot 2022-11-09 at 8 04 07 PM" src="https://user-images.githubusercontent.com/73618019/201004911-f8533730-d418-40bf-9254-6c153e961359.png">

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:
