### PR TITLE
[Chat][fix] Resize activity for keyboard

### DIFF
--- a/azure-communication-ui/chat/src/main/AndroidManifest.xml
+++ b/azure-communication-ui/chat/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
             android:exported="false"
             android:label="@string/azure_communication_ui_chat_title_activity_compose_chat"
             android:theme="@style/AzureCommunicationUIChat.Theme"
+            android:windowSoftInputMode="adjustResize"
             />
     </application>
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This PR adjusts the resize mode for the chat composite activity, allowing android to resize it to accommodate the soft keyboard

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Join a chat thread 
* Tap on the input box to bring up the keyboard


## What to Check
Verify that the following are valid
* The activity should now resize instead of offsetting upwards

## Screenshots

### Before:

![Screenshot_1668104307](https://user-images.githubusercontent.com/43901/201175654-176cfcd1-9b0f-40ef-b891-086ee66184f0.png)


### After:
![Screenshot_1668104321](https://user-images.githubusercontent.com/43901/201175683-fb34b4d6-a281-4161-b781-a506b0ce6725.png)

