### PR TITLE
[Bugfix][Chat] participants list items are now full width

### DIFF
--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/ParticipantsListView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/ParticipantsListView.kt
@@ -6,6 +6,7 @@
 package com.azure.android.communication.ui.chat.presentation.ui.chat.components
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -23,7 +24,7 @@ internal fun ParticipantsListView(
 ) {
     Column(modifier = modifier) {
         ListSubHeaderView(text = stringResource(id = R.string.azure_communication_ui_chat_in_this_chat_count, participants.count()))
-        LazyColumn() {
+        LazyColumn(modifier = Modifier.fillMaxWidth()) {
             items(items = participants, key = { it.userIdentifier.id }, itemContent = { it -> ParticipantView(participant = it) })
         }
     }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix for not being able to scroll from the empty space on the participants list

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Create + join a chat thread with many participants, such that the participants list scrolls on the device
* Scroll from the right side of the list, touch should be on a whitespace area


## What to Check
Verify that the following are valid
* the participants list items occupy the full width, receive and handle the touch and the list items scroll as expected
