### PR TITLE
[Chat][Bug] Input view box clipping + new line button

### DIFF
--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.res.stringResource
 import com.azure.android.communication.ui.chat.R
 import com.azure.android.communication.ui.chat.presentation.ui.chat.UITestTags
 import com.azure.android.communication.ui.chat.redux.action.Action
-import com.azure.android.communication.ui.chat.redux.action.ChatAction
 
 @Composable
 internal fun MessageInputView(

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.res.stringResource
 import com.azure.android.communication.ui.chat.R
 import com.azure.android.communication.ui.chat.presentation.ui.chat.UITestTags
 import com.azure.android.communication.ui.chat.redux.action.Action
+import com.azure.android.communication.ui.chat.redux.action.ChatAction
 
 @Composable
 internal fun MessageInputView(
@@ -50,6 +51,7 @@ internal fun MessageInputView(
     MessageInput(
         onTextChanged = {
             messageInputTextState.value = it
+            postAction(ChatAction.TypingIndicator())
         },
         textContent = messageInputTextState.value,
         onTextFieldFocused = { focusState = it },

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
@@ -51,7 +51,6 @@ internal fun MessageInputView(
     MessageInput(
         onTextChanged = {
             messageInputTextState.value = it
-            postAction(ChatAction.TypingIndicator())
         },
         textContent = messageInputTextState.value,
         onTextFieldFocused = { focusState = it },
@@ -106,7 +105,7 @@ internal fun MessageInput(
             Box(
                 modifier = Modifier
                     .border(1.dp, outlineColor, RoundedCornerShape(10))
-                    .padding(6.dp, 0.dp, 6.dp, 0.dp),
+                    .padding(6.dp, 6.dp, 6.dp, 6.dp),
                 contentAlignment = Alignment.CenterStart,
             ) {
 

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
@@ -86,8 +86,8 @@ internal fun MessageInput(
     BasicTextField(
         modifier = Modifier
             .fillMaxWidth(fraction = 0.9f)
-            .padding(5.dp)
-            .heightIn(52.dp, maxInputHeight)
+            .padding(6.dp)
+            .heightIn(40.dp, maxInputHeight)
             .onFocusChanged { onTextFieldFocused(it.isFocused) }
             .testTag(UITestTags.MESSAGE_INPUT_BOX)
             .then(semantics),
@@ -99,17 +99,16 @@ internal fun MessageInput(
         ),
         keyboardOptions = KeyboardOptions(
             keyboardType = keyboardType,
-            imeAction = ImeAction.Send
+            imeAction = ImeAction.Default
         ),
         keyboardActions = keyboardActions,
         decorationBox = { innerTextField ->
             Box(
                 modifier = Modifier
                     .border(1.dp, outlineColor, RoundedCornerShape(10))
-                    .padding(6.dp, 6.dp, 6.dp, 6.dp),
+                    .padding(9.dp, 6.dp, 9.dp, 6.dp),
                 contentAlignment = Alignment.CenterStart,
             ) {
-
                 if (textContent.isEmpty() && !focusState) {
                     BasicText(
                         text = stringResource(R.string.azure_communication_ui_chat_enter_a_message),

--- a/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
+++ b/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
@@ -6,7 +6,7 @@
     <string name="azure_communication_ui_chat_chat_action_bar_title">Chat</string>
     <string name="azure_communication_ui_chat_title_activity_compose_chat">ComposeChatActivity</string>
     <string name="azure_communication_ui_chat_demo_app_title">Chat Composite Demo App</string>
-    <string name="azure_communication_ui_chat_enter_a_message">Type a new message</string>
+    <string name="azure_communication_ui_chat_enter_a_message">Type a message</string>
     <string name="azure_communication_ui_chat_other">other</string>
     <string name="azure_communication_ui_chat_others">others</string>
     <string name="azure_communication_ui_chat_unread_new_message">1 new message</string>

--- a/azure-communication-ui/demo-app/src/chat/java/com/azure/android/communication/ui/chatdemoapp/launcher/ChatCompositeLauncher.java
+++ b/azure-communication-ui/demo-app/src/chat/java/com/azure/android/communication/ui/chatdemoapp/launcher/ChatCompositeLauncher.java
@@ -9,6 +9,6 @@ public interface ChatCompositeLauncher {
     void launch(ChatLauncherActivity chatLauncherActivity,
                 String threadID,
                 String endPointURL,
-                String toString,
+                String displayName,
                 String identity);
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Message input now clipping text at top left edge. Also renamed a parameter from "toString" to "displayName". 
Keyboard send message button is not replaced with "new line button". Confirmed with Alex P.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
