### PR TITLE
[Chat][Bug] Send message new line + input box clipping fix

### DIFF
--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/BottomBarView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/BottomBarView.kt
@@ -6,7 +6,6 @@ package com.azure.android.communication.ui.chat.presentation.ui.chat.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -38,9 +37,6 @@ internal fun BottomBarView(
             contentDescription = stringResource(R.string.azure_communication_ui_chat_message_input_view_content_description),
             messageInputTextState = messageInputTextState,
             postAction = postAction,
-            keyboardActions = KeyboardActions(onSend = {
-                sendButtonOnclick(postAction, messageInputTextState)
-            })
         )
 
         SendMessageButtonView(

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageInputView.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -21,7 +20,6 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -86,8 +84,8 @@ internal fun MessageInput(
     BasicTextField(
         modifier = Modifier
             .fillMaxWidth(fraction = 0.9f)
-            .padding(5.dp)
-            .heightIn(52.dp, maxInputHeight)
+            .padding(6.dp)
+            .heightIn(40.dp, maxInputHeight)
             .onFocusChanged { onTextFieldFocused(it.isFocused) }
             .testTag(UITestTags.MESSAGE_INPUT_BOX)
             .then(semantics),
@@ -97,16 +95,13 @@ internal fun MessageInput(
         textStyle = TextStyle(
             color = textColor
         ),
-        keyboardOptions = KeyboardOptions(
-            keyboardType = keyboardType,
-            imeAction = ImeAction.Send
-        ),
+        singleLine = false,
         keyboardActions = keyboardActions,
         decorationBox = { innerTextField ->
             Box(
                 modifier = Modifier
                     .border(1.dp, outlineColor, RoundedCornerShape(10))
-                    .padding(6.dp, 0.dp, 6.dp, 0.dp),
+                    .padding(9.dp, 6.dp, 9.dp, 6.dp),
                 contentAlignment = Alignment.CenterStart,
             ) {
 

--- a/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
+++ b/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
@@ -6,7 +6,7 @@
     <string name="azure_communication_ui_chat_chat_action_bar_title">Chat</string>
     <string name="azure_communication_ui_chat_title_activity_compose_chat">ComposeChatActivity</string>
     <string name="azure_communication_ui_chat_demo_app_title">Chat Composite Demo App</string>
-    <string name="azure_communication_ui_chat_enter_a_message">Type a new message</string>
+    <string name="azure_communication_ui_chat_enter_a_message">Type a message</string>
     <string name="azure_communication_ui_chat_other">other</string>
     <string name="azure_communication_ui_chat_others">others</string>
     <string name="azure_communication_ui_chat_unread_new_message">1 new message</string>

--- a/azure-communication-ui/demo-app/src/chat/java/com/azure/android/communication/ui/chatdemoapp/launcher/ChatCompositeLauncher.java
+++ b/azure-communication-ui/demo-app/src/chat/java/com/azure/android/communication/ui/chatdemoapp/launcher/ChatCompositeLauncher.java
@@ -9,6 +9,6 @@ public interface ChatCompositeLauncher {
     void launch(ChatLauncherActivity chatLauncherActivity,
                 String threadID,
                 String endPointURL,
-                String toString,
+                String displayName,
                 String identity);
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Message input now clipping text at top left edge. Also renamed a parameter from "toString" to "displayName".
Keyboard send message button is not replaced with "new line button". Confirmed with Alex P.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
