### PR TITLE
Keyboard Show/Hide behaviours + Scroll to Bottom on Message Post + Participant List Tile Width

### DIFF
--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/ListItemView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/ListItemView.kt
@@ -6,7 +6,9 @@
 package com.azure.android.communication.ui.chat.presentation.ui.chat.components
 
 import android.view.View
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
@@ -17,12 +19,15 @@ internal fun ListItemView(
     title: String,
     customView: View? = null,
 ) {
-    AndroidView(factory = { context ->
-        com.microsoft.fluentui.listitem.ListItemView(context).apply {
-            this.title = title
-            this.customView = customView
+    AndroidView(
+        modifier = Modifier.fillMaxWidth(),
+        factory = { context ->
+            com.microsoft.fluentui.listitem.ListItemView(context).apply {
+                this.title = title
+                this.customView = customView
+            }
         }
-    })
+    )
 }
 
 @Preview

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageListView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageListView.kt
@@ -3,6 +3,11 @@
 
 package com.azure.android.communication.ui.chat.presentation.ui.chat.components
 
+import android.app.Activity
+import android.content.Context
+import android.graphics.Rect
+import android.view.ViewTreeObserver
+import android.view.inputmethod.InputMethodManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -12,16 +17,19 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
-
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat.getSystemService
 import com.azure.android.communication.ui.chat.presentation.ui.viewmodel.MessageViewModel
 import com.azure.android.communication.ui.chat.presentation.ui.viewmodel.toViewModelList
 import com.azure.android.communication.ui.chat.preview.MOCK_LOCAL_USER_ID
@@ -30,6 +38,7 @@ import com.azure.android.communication.ui.chat.redux.Dispatch
 import com.azure.android.communication.ui.chat.redux.action.ChatAction
 import com.azure.android.communication.ui.chat.utilities.outOfViewItemCount
 import com.jakewharton.threetenabp.AndroidThreeTen
+import kotlinx.coroutines.launch
 
 const val MESSAGE_LIST_LOAD_MORE_THRESHOLD = 40
 
@@ -42,6 +51,8 @@ internal fun MessageListView(
     dispatchers: Dispatch
 ) {
     requestPages(scrollState, messages, dispatchers)
+    scrollToNewestWhenKeyboardOpen(scrollState)
+    dismissKeyboardWhenScrollUp(scrollState)
     if (messages.isNotEmpty()) {
         sendReadReceipt(scrollState, messages, dispatchers)
         autoScrollToBottom(scrollState, messages)
@@ -106,6 +117,76 @@ private fun autoScrollToBottom(
         }
     }
     wasAtEnd.value = isAtEnd
+}
+
+enum class Keyboard {
+    Opened, Closed
+}
+
+@Composable
+private fun scrollToNewestWhenKeyboardOpen(scrollState: LazyListState) {
+    val coroutineScope = rememberCoroutineScope()
+    val triggered = remember { mutableStateOf(false) }
+    val view = LocalView.current
+    DisposableEffect(view) {
+        val onGlobalListener = ViewTreeObserver.OnGlobalLayoutListener {
+            val rect = Rect()
+            view.getWindowVisibleDisplayFrame(rect)
+            val screenHeight = view.rootView.height
+            val keypadHeight = screenHeight - rect.bottom
+            if (keypadHeight > screenHeight * 0.15) {
+                if (!triggered.value) {
+                    coroutineScope.launch {
+                        scrollState.animateScrollToItem(0)
+                    }
+                }
+                triggered.value = true
+            } else {
+                triggered.value = false
+            }
+        }
+        view.viewTreeObserver.addOnGlobalLayoutListener(onGlobalListener)
+
+        onDispose {
+            view.viewTreeObserver.removeOnGlobalLayoutListener(onGlobalListener)
+        }
+    }
+}
+
+@Composable
+private fun dismissKeyboardWhenScrollUp(scrollState: LazyListState) {
+    val coroutineScope = rememberCoroutineScope()
+    val opened = remember { mutableStateOf(false) }
+    val view = LocalView.current
+
+    val atBottom = remember { mutableStateOf(scrollState.firstVisibleItemIndex == 0) }
+    val currentlyAtBottom = scrollState.firstVisibleItemIndex == 0
+    if (atBottom.value && !currentlyAtBottom && opened.value) {
+        val activity = (LocalView.current.context as Activity)
+        LaunchedEffect("KeyboardCloseEffect") {
+            coroutineScope.launch {
+                val imm: InputMethodManager? =
+                    activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
+                imm?.hideSoftInputFromWindow(view.windowToken, 0)
+            }
+        }
+    }
+    atBottom.value = currentlyAtBottom
+
+    DisposableEffect(view) {
+        val onGlobalListener = ViewTreeObserver.OnGlobalLayoutListener {
+            val rect = Rect()
+            view.getWindowVisibleDisplayFrame(rect)
+            val screenHeight = view.rootView.height
+            val keypadHeight = screenHeight - rect.bottom
+            opened.value = (keypadHeight > screenHeight * 0.15)
+        }
+        view.viewTreeObserver.addOnGlobalLayoutListener(onGlobalListener)
+
+        onDispose {
+            view.viewTreeObserver.removeOnGlobalLayoutListener(onGlobalListener)
+        }
+    }
 }
 
 @Composable

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/ParticipantView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/ParticipantView.kt
@@ -18,6 +18,7 @@ import com.microsoft.fluentui.persona.AvatarView
 internal fun ParticipantView(participant: RemoteParticipantInfoModel) {
     val participantName = participant.displayName ?: stringResource(id = R.string.azure_communication_ui_chat_unnamed_participant)
     val avatarView = AvatarView(LocalContext.current).apply { name = participantName }
+
     ListItemView(title = participantName, avatarView)
 }
 

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/ParticipantsListView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/ParticipantsListView.kt
@@ -6,6 +6,7 @@
 package com.azure.android.communication.ui.chat.presentation.ui.chat.components
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -21,9 +22,9 @@ internal fun ParticipantsListView(
     participants: List<RemoteParticipantInfoModel>,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier) {
+    Column(modifier = modifier.fillMaxWidth()) {
         ListSubHeaderView(text = stringResource(id = R.string.azure_communication_ui_chat_in_this_chat_count, participants.count()))
-        LazyColumn() {
+        LazyColumn(modifier = modifier.fillMaxWidth()) {
             items(items = participants, key = { it.userIdentifier.id }, itemContent = { it -> ParticipantView(participant = it) })
         }
     }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/ChatScreen.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/ChatScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Scaffold
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -43,6 +45,8 @@ import com.azure.android.communication.ui.chat.redux.action.NavigationAction
 import com.azure.android.communication.ui.chat.redux.state.ChatStatus
 import com.azure.android.communication.ui.chat.service.sdk.wrapper.CommunicationIdentifier
 import com.jakewharton.threetenabp.AndroidThreeTen
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun ChatScreen(
@@ -51,6 +55,7 @@ internal fun ChatScreen(
 ) {
     val scaffoldState = rememberScaffoldState()
     val listState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
 
     Scaffold(
         scaffoldState = scaffoldState,
@@ -126,13 +131,20 @@ internal fun ChatScreen(
             Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 Box(Modifier.width(ChatCompositeTheme.dimensions.messageListMaxWidth)) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Box(modifier = Modifier.align(alignment = Alignment.Start).padding(horizontal = 5.dp)) {
+                        Box(modifier = Modifier
+                            .align(alignment = Alignment.Start)
+                            .padding(horizontal = 5.dp)) {
                             TypingIndicatorView(viewModel.typingParticipants.toList())
                         }
                         BottomBarView(
                             messageInputTextState = stateViewModel.messageInputTextState,
                             chatStatus = viewModel.chatStatus,
-                            postAction = viewModel.postAction
+                            postAction = {
+                                coroutineScope.launch {
+                                    listState.animateScrollToItem(0)
+                                }
+                                viewModel.postAction(it)
+                            }
                         )
                     }
                 }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/ChatScreen.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/ChatScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Scaffold
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -131,9 +130,11 @@ internal fun ChatScreen(
             Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 Box(Modifier.width(ChatCompositeTheme.dimensions.messageListMaxWidth)) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Box(modifier = Modifier
-                            .align(alignment = Alignment.Start)
-                            .padding(horizontal = 5.dp)) {
+                        Box(
+                            modifier = Modifier
+                                .align(alignment = Alignment.Start)
+                                .padding(horizontal = 5.dp)
+                        ) {
                             TypingIndicatorView(viewModel.typingParticipants.toList())
                         }
                         BottomBarView(


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Scroll to Bottom when Keyboard is displayed
* Hide Keyboard when scroll away from bottom
* Scroll to bottom after post message (even if you scroll up and dismiss keyboard then post)
* Fix participant width issues with scrolling

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
