### PR TITLE
[Call][Bug] fix crash on cancel call for Xamarin

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmView.kt
@@ -152,12 +152,16 @@ internal class LeaveConfirmView(
             info: AccessibilityNodeInfoCompat
         ) {
             super.onInitializeAccessibilityNodeInfoForItem(recycler, state, host, info)
-            val itemInfo = AccessibilityNodeInfoCompat.CollectionItemInfoCompat.obtain(max(info.collectionItemInfo.rowIndex - 1, 0), info.collectionItemInfo.rowSpan, info.collectionItemInfo.columnIndex, info.collectionItemInfo.columnSpan, info.collectionItemInfo.isHeading, info.collectionItemInfo.isSelected)
-            if (info.collectionItemInfo.rowIndex == 0) {
-                info.setCollectionItemInfo(null)
-            } else {
-                info.setCollectionItemInfo(itemInfo)
-            }
+            try {
+                info?.let {
+                    val itemInfo = AccessibilityNodeInfoCompat.CollectionItemInfoCompat.obtain(max(info.collectionItemInfo.rowIndex - 1, 0), info.collectionItemInfo.rowSpan, info.collectionItemInfo.columnIndex, info.collectionItemInfo.columnSpan, info.collectionItemInfo.isHeading, info.collectionItemInfo.isSelected)
+                    if (info.collectionItemInfo.rowIndex == 0) {
+                        info.setCollectionItemInfo(null)
+                    } else {
+                        info.setCollectionItemInfo(itemInfo)
+                    }
+                }
+            } catch (e: Exception) {}
         }
     }
 }

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmView.kt
@@ -161,7 +161,10 @@ internal class LeaveConfirmView(
                         info.setCollectionItemInfo(itemInfo)
                     }
                 }
-            } catch (e: Exception) {}
+            } catch (e: Exception) {
+                // Xamarin cause exception, info is null
+                // Cause: -\java.lang.NullPointerException: Attempt to invoke virtual method 'int androidx.core.view.accessibility.AccessibilityNodeInfoCompat$CollectionItemInfoCompat.getRowIndex()
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* fix crash on cancel call for Xamarin
* Cause: -\java.lang.NullPointerException: Attempt to invoke virtual method 'int androidx.core.view.accessibility.AccessibilityNodeInfoCompat$CollectionItemInfoCompat.getRowIndex()

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

