### PR TITLE
[Call][Bug] fix call join not working if no camera

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/SetupViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/SetupViewModel.kt
@@ -66,7 +66,8 @@ internal class SetupViewModel(
         joinCallButtonHolderViewModel.init(
             state.permissionState.audioPermissionState,
             state.permissionState.cameraPermissionState,
-            state.localParticipantState.cameraState.operation
+            state.localParticipantState.cameraState.operation,
+            state.localParticipantState.cameraState.camerasCount
         )
 
         super.init(coroutineScope)
@@ -102,7 +103,8 @@ internal class SetupViewModel(
             state.permissionState.audioPermissionState,
             state.callState,
             state.permissionState.cameraPermissionState,
-            state.localParticipantState.cameraState.operation
+            state.localParticipantState.cameraState.operation,
+            state.localParticipantState.cameraState.camerasCount
         )
     }
 }

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/JoinCallButtonHolderViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/JoinCallButtonHolderViewModel.kt
@@ -33,13 +33,14 @@ internal class JoinCallButtonHolderViewModel(private val dispatch: (Action) -> U
     fun init(
         audioPermissionState: PermissionStatus,
         cameraPermissionState: PermissionStatus,
-        cameraOperationalStatus: CameraOperationalStatus
+        cameraOperationalStatus: CameraOperationalStatus,
+        camerasCount: Int,
     ) {
         joinCallButtonEnabledFlow =
             MutableStateFlow(
                 audioPermissionState == PermissionStatus.GRANTED &&
                     cameraPermissionState != PermissionStatus.UNKNOWN &&
-                    cameraOperationalStatus != CameraOperationalStatus.PENDING
+                    (camerasCount == 0 || cameraOperationalStatus != CameraOperationalStatus.PENDING)
             )
         disableJoinCallButtonFlow.value = false
     }
@@ -48,13 +49,14 @@ internal class JoinCallButtonHolderViewModel(private val dispatch: (Action) -> U
         audioPermissionState: PermissionStatus,
         callingState: CallingState,
         cameraPermissionState: PermissionStatus,
-        cameraOperationalStatus: CameraOperationalStatus
+        cameraOperationalStatus: CameraOperationalStatus,
+        camerasCount: Int,
     ) {
         disableJoinCallButtonFlow.value = callingState.callingStatus != CallingStatus.NONE
         joinCallButtonEnabledFlow.value =
             audioPermissionState == PermissionStatus.GRANTED &&
             cameraPermissionState != PermissionStatus.UNKNOWN &&
-            cameraOperationalStatus != CameraOperationalStatus.PENDING
+            (camerasCount == 0 || cameraOperationalStatus != CameraOperationalStatus.PENDING)
         if (callingState.isDisconnected()) {
             disableJoinCallButtonFlow.value = false
         } else {

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDKWrapper.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/service/sdk/CallingSDKWrapper.kt
@@ -176,7 +176,7 @@ internal class CallingSDKWrapper(
             var videoOptions: VideoOptions? = null
             // it is possible to have camera state not on, (Example: waiting for local video stream)
             // if camera on is in progress, the waiting will make sure for starting call with right state
-            if (cameraState.operation != CameraOperationalStatus.OFF) {
+            if (camerasCountStateFlow.value != 0 && cameraState.operation != CameraOperationalStatus.OFF) {
                 getLocalVideoStream().whenComplete { videoStream, error ->
                     if (error == null) {
                         val localVideoStreams =

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/presentation/fragment/setup/components/JoinCallButtonHolderViewModelUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/presentation/fragment/setup/components/JoinCallButtonHolderViewModelUnitTest.kt
@@ -34,7 +34,8 @@ internal class JoinCallButtonHolderViewModelUnitTest : ACSBaseTestCoroutine() {
             viewModel.init(
                 PermissionStatus.DENIED,
                 PermissionStatus.GRANTED,
-                CameraOperationalStatus.ON
+                CameraOperationalStatus.ON,
+                2
             )
 
             val emitResult = mutableListOf<Boolean>()
@@ -49,7 +50,8 @@ internal class JoinCallButtonHolderViewModelUnitTest : ACSBaseTestCoroutine() {
                 PermissionStatus.GRANTED,
                 CallingState(CallingStatus.NONE),
                 PermissionStatus.GRANTED,
-                CameraOperationalStatus.ON
+                CameraOperationalStatus.ON,
+                2
             )
 
             // assert
@@ -77,7 +79,8 @@ internal class JoinCallButtonHolderViewModelUnitTest : ACSBaseTestCoroutine() {
             viewModel.init(
                 PermissionStatus.GRANTED,
                 PermissionStatus.GRANTED,
-                CameraOperationalStatus.ON
+                CameraOperationalStatus.ON,
+                2
             )
 
             val emitResult = mutableListOf<Boolean>()
@@ -92,7 +95,8 @@ internal class JoinCallButtonHolderViewModelUnitTest : ACSBaseTestCoroutine() {
                 PermissionStatus.DENIED,
                 CallingState(CallingStatus.NONE),
                 PermissionStatus.GRANTED,
-                CameraOperationalStatus.ON
+                CameraOperationalStatus.ON,
+                2
             )
 
             // assert
@@ -120,7 +124,8 @@ internal class JoinCallButtonHolderViewModelUnitTest : ACSBaseTestCoroutine() {
             viewModel.init(
                 PermissionStatus.GRANTED,
                 PermissionStatus.GRANTED,
-                CameraOperationalStatus.ON
+                CameraOperationalStatus.ON,
+                2
             )
 
             val emitResult = mutableListOf<Boolean>()
@@ -140,7 +145,8 @@ internal class JoinCallButtonHolderViewModelUnitTest : ACSBaseTestCoroutine() {
                 PermissionStatus.GRANTED,
                 CallingState(CallingStatus.CONNECTING),
                 PermissionStatus.GRANTED,
-                CameraOperationalStatus.ON
+                CameraOperationalStatus.ON,
+                2
             )
 
             // assert
@@ -153,7 +159,8 @@ internal class JoinCallButtonHolderViewModelUnitTest : ACSBaseTestCoroutine() {
                 PermissionStatus.GRANTED,
                 CallingState(CallingStatus.NONE),
                 PermissionStatus.GRANTED,
-                CameraOperationalStatus.ON
+                CameraOperationalStatus.ON,
+                2
             )
 
             // assert
@@ -174,7 +181,8 @@ internal class JoinCallButtonHolderViewModelUnitTest : ACSBaseTestCoroutine() {
             viewModel.init(
                 PermissionStatus.GRANTED,
                 PermissionStatus.GRANTED,
-                CameraOperationalStatus.ON
+                CameraOperationalStatus.ON,
+                2
             )
 
             val emitResult = mutableListOf<Boolean>()
@@ -189,7 +197,8 @@ internal class JoinCallButtonHolderViewModelUnitTest : ACSBaseTestCoroutine() {
                 PermissionStatus.GRANTED,
                 CallingState(CallingStatus.NONE),
                 PermissionStatus.UNKNOWN,
-                CameraOperationalStatus.ON
+                CameraOperationalStatus.ON,
+                2
             )
 
             // assert
@@ -217,7 +226,8 @@ internal class JoinCallButtonHolderViewModelUnitTest : ACSBaseTestCoroutine() {
             viewModel.init(
                 PermissionStatus.GRANTED,
                 PermissionStatus.GRANTED,
-                CameraOperationalStatus.ON
+                CameraOperationalStatus.ON,
+                2
             )
 
             val emitResult = mutableListOf<Boolean>()
@@ -232,7 +242,8 @@ internal class JoinCallButtonHolderViewModelUnitTest : ACSBaseTestCoroutine() {
                 PermissionStatus.GRANTED,
                 CallingState(CallingStatus.NONE),
                 PermissionStatus.UNKNOWN,
-                CameraOperationalStatus.PENDING
+                CameraOperationalStatus.PENDING,
+                2
             )
 
             // assert


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
*  fix call join not working if TV have no camera connected

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
