### PR TITLE
Move LocalParticipantInfoModel into participantState, clean up extra action, remove from MessageRepoMiddleware

### DIFF
--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/error/EventHandler.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/error/EventHandler.kt
@@ -19,7 +19,7 @@ internal class EventHandler(
     private val configuration: ChatCompositeConfiguration,
 ) {
     private var isActiveChatThreadParticipantStateFlow = MutableStateFlow(
-        store.getCurrentState().chatState.localParticipantInfoModel.isActiveChatThreadParticipant
+        store.getCurrentState().participantState.localParticipantInfoModel.isActiveChatThreadParticipant
     )
 
     private val coroutineScope = CoroutineScope((coroutineContextProvider.Default))
@@ -28,7 +28,7 @@ internal class EventHandler(
         coroutineScope.launch(Dispatchers.Default) {
             store.getStateFlow().collect {
                 isActiveChatThreadParticipantStateFlow.value =
-                    it.chatState.localParticipantInfoModel.isActiveChatThreadParticipant
+                    it.participantState.localParticipantInfoModel.isActiveChatThreadParticipant
             }
         }
 
@@ -48,7 +48,7 @@ internal class EventHandler(
     ) {
         if (!isActiveChatThreadParticipant) {
             configuration.eventHandlerRepository.getLocalParticipantRemovedHandlers().forEach {
-                it.handle(store.getCurrentState().chatState.localParticipantInfoModel.userIdentifier)
+                it.handle(store.getCurrentState().participantState.localParticipantInfoModel.userIdentifier)
             }
         }
     }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/ChatScreenViewModel.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/ChatScreenViewModel.kt
@@ -69,7 +69,7 @@ internal fun buildChatScreenViewModel(
         chatTopic = store.getCurrentState().chatState.chatInfoModel.topic,
         navigationStatus = store.getCurrentState().navigationState.navigationStatus,
         messageContextMenu = store.getCurrentState().chatState.messageContextMenu ?: MessageContextMenuModel(messageInfoModel = EMPTY_MESSAGE_INFO_MODEL, emptyList()),
-        enableSendMessageButton = store.getCurrentState().chatState.localParticipantInfoModel.isActiveChatThreadParticipant &&
+        enableSendMessageButton = store.getCurrentState().participantState.localParticipantInfoModel.isActiveChatThreadParticipant &&
             store.getCurrentState().chatState.chatStatus == ChatStatus.INITIALIZED
     )
 }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/action/ChatAction.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/action/ChatAction.kt
@@ -25,7 +25,6 @@ internal sealed class ChatAction : Action {
     class MessageRead(val messageId: String) : ChatAction()
     class MessageLastReceived(val messageId: String) : ChatAction()
     class TypingIndicator : ChatAction()
-    object LocalUserRemoved : ChatAction()
     class ShowMessageContextMenu(val message: MessageInfoModel) : ChatAction()
     class HideMessageContextMenu : ChatAction()
     class CopyMessageText(val message: MessageInfoModel) : ChatAction()

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/middleware/repository/MessageRepositoryMiddleware.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/middleware/repository/MessageRepositoryMiddleware.kt
@@ -145,9 +145,6 @@ internal class MessageRepositoryMiddlewareImpl(
         action: ParticipantAction.ParticipantsRemoved,
         dispatch: Dispatch,
     ) {
-        if (action.localParticipantRemoved) {
-            dispatch(ChatAction.LocalUserRemoved)
-        }
 
         if (action.participants.isNotEmpty()) {
             messageRepository.addMessage(

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/middleware/sdk/ChatServiceListener.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/middleware/sdk/ChatServiceListener.kt
@@ -60,7 +60,7 @@ internal class ChatServiceListener(
                 handleInfoModel(
                     it,
                     dispatch,
-                    store.getCurrentState().chatState.localParticipantInfoModel
+                    store.getCurrentState().participantState.localParticipantInfoModel
                 )
             }
         }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/AppStateReducer.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/AppStateReducer.kt
@@ -20,8 +20,8 @@ internal class AppStateReducer(
     override fun reduce(state: ReduxState, action: Action): ReduxState {
         val appState = AppReduxState(
             threadID = state.chatState.chatInfoModel.threadId,
-            localParticipantIdentifier = state.chatState.localParticipantInfoModel.userIdentifier,
-            localParticipantDisplayName = state.chatState.localParticipantInfoModel.displayName,
+            localParticipantIdentifier = state.participantState.localParticipantInfoModel.userIdentifier,
+            localParticipantDisplayName = state.participantState.localParticipantInfoModel.displayName,
         )
 
         appState.chatState = chatReducer.reduce(

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/ChatReducer.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/ChatReducer.kt
@@ -82,12 +82,6 @@ internal class ChatReducerImpl : ChatReducer {
                     )
                 )
             }
-            is ChatAction.LocalUserRemoved -> {
-                state.copy(
-                    localParticipantInfoModel =
-                    state.localParticipantInfoModel.copy(isActiveChatThreadParticipant = false)
-                )
-            }
             else -> state
         }
     }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/ParticipantsReducer.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/ParticipantsReducer.kt
@@ -34,12 +34,24 @@ internal class ParticipantsReducerImpl : ParticipantsReducer {
                     participantTyping =
                         participantTyping - participantTypingKeys.filter { it.contains(id) }
                 }
-                state.copy(
+
+                var lstate = state;
+
+                if (action.localParticipantRemoved) {
+                    lstate = state.copy(
+                        localParticipantInfoModel =
+                        state.localParticipantInfoModel.copy(isActiveChatThreadParticipant = false)
+                    )
+                }
+
+                lstate.copy(
                     participants = state.participants - removedParticipants,
                     participantTyping = participantTyping,
                     participantsReadReceiptMap =
                     state.participantsReadReceiptMap - action.participants.map { it.userIdentifier.id }
                 )
+
+
             }
             is ParticipantAction.AddParticipantTyping -> {
                 val id = action.infoModel.userIdentifier.id

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/ParticipantsReducer.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/ParticipantsReducer.kt
@@ -35,16 +35,16 @@ internal class ParticipantsReducerImpl : ParticipantsReducer {
                         participantTyping - participantTypingKeys.filter { it.contains(id) }
                 }
 
-                var lstate = state;
+                var updatedState = state;
 
                 if (action.localParticipantRemoved) {
-                    lstate = state.copy(
+                    updatedState = updatedState.copy(
                         localParticipantInfoModel =
                         state.localParticipantInfoModel.copy(isActiveChatThreadParticipant = false)
                     )
                 }
 
-                lstate.copy(
+                updatedState.copy(
                     participants = state.participants - removedParticipants,
                     participantTyping = participantTyping,
                     participantsReadReceiptMap =

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/ParticipantsReducer.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/reducer/ParticipantsReducer.kt
@@ -35,7 +35,7 @@ internal class ParticipantsReducerImpl : ParticipantsReducer {
                         participantTyping - participantTypingKeys.filter { it.contains(id) }
                 }
 
-                var lstate = state;
+                var lstate = state
 
                 if (action.localParticipantRemoved) {
                     lstate = state.copy(
@@ -50,8 +50,6 @@ internal class ParticipantsReducerImpl : ParticipantsReducer {
                     participantsReadReceiptMap =
                     state.participantsReadReceiptMap - action.participants.map { it.userIdentifier.id }
                 )
-
-
             }
             is ParticipantAction.AddParticipantTyping -> {
                 val id = action.infoModel.userIdentifier.id

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/AppReduxState.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/AppReduxState.kt
@@ -16,10 +16,6 @@ internal class AppReduxState(
 ) : ReduxState {
     override var chatState: ChatState = ChatState(
         chatStatus = ChatStatus.NONE,
-        localParticipantInfoModel = LocalParticipantInfoModel(
-            userIdentifier = localParticipantIdentifier,
-            displayName = localParticipantDisplayName
-        ),
         chatInfoModel = ChatInfoModel(
             threadId = threadID,
             topic = null,
@@ -32,6 +28,10 @@ internal class AppReduxState(
     )
 
     override var participantState: ParticipantsState = ParticipantsState(
+        localParticipantInfoModel = LocalParticipantInfoModel(
+            userIdentifier = localParticipantIdentifier,
+            displayName = localParticipantDisplayName
+        ),
         participants = mapOf(),
         participantTyping = mapOf(),
         participantsReadReceiptMap = mapOf(),

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/ChatState.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/ChatState.kt
@@ -4,7 +4,6 @@
 package com.azure.android.communication.ui.chat.redux.state
 
 import com.azure.android.communication.ui.chat.models.ChatInfoModel
-import com.azure.android.communication.ui.chat.models.LocalParticipantInfoModel
 import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
 
 // ChatStatus will help to subscribe to real tim notifications when state is initialized

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/ChatState.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/ChatState.kt
@@ -17,7 +17,6 @@ internal enum class ChatStatus {
 
 internal data class ChatState(
     val chatStatus: ChatStatus,
-    val localParticipantInfoModel: LocalParticipantInfoModel,
     val chatInfoModel: ChatInfoModel,
     val lastReadMessageId: String,
     val lastSendMessageId: String,

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/ParticipantsState.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/redux/state/ParticipantsState.kt
@@ -3,6 +3,7 @@
 
 package com.azure.android.communication.ui.chat.redux.state
 
+import com.azure.android.communication.ui.chat.models.LocalParticipantInfoModel
 import com.azure.android.communication.ui.chat.models.RemoteParticipantInfoModel
 import org.threeten.bp.OffsetDateTime
 
@@ -11,4 +12,5 @@ internal data class ParticipantsState(
     val participantTyping: Map<String, String>,
     val participantsReadReceiptMap: Map<String, OffsetDateTime>,
     val latestReadMessageTimestamp: OffsetDateTime,
+    val localParticipantInfoModel: LocalParticipantInfoModel,
 )


### PR DESCRIPTION
re-use ParticipantRemovedAction to update it instead of second ChatAction

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
