### PR TITLE
[Chat][Refactor] get read receipts working

### DIFF
--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageView.kt
@@ -53,11 +53,13 @@ internal fun MessageView(viewModel: MessageViewModel, dispatch: Dispatch) {
         return
     }
     Column(
-        modifier = Modifier.padding(ChatCompositeTheme.dimensions.messageOuterPadding).semantics(mergeDescendants = true) {
-            // Despite the "", it's still merging/reading the children as they are on
-            // the screen.
-            contentDescription = ""
-        },
+        modifier = Modifier
+            .padding(ChatCompositeTheme.dimensions.messageOuterPadding)
+            .semantics(mergeDescendants = true) {
+                // Despite the "", it's still merging/reading the children as they are on
+                // the screen.
+                contentDescription = ""
+            },
     ) {
 
         // Date Header Part
@@ -88,7 +90,9 @@ internal fun MessageView(viewModel: MessageViewModel, dispatch: Dispatch) {
             ChatMessageType.PARTICIPANT_ADDED -> SystemMessage(
                 icon = R.drawable.azure_communication_ui_chat_ic_participant_added_filled,
                 stringResource = R.string.azure_communication_ui_chat_joined_chat,
-                substitution = viewModel.message.participants.map { it.displayName ?: "Participant" }
+                substitution = viewModel.message.participants.map {
+                    it.displayName ?: "Participant"
+                }
             )
             ChatMessageType.PARTICIPANT_REMOVED -> if (viewModel.message.isCurrentUser)
                 SystemMessage(
@@ -99,11 +103,13 @@ internal fun MessageView(viewModel: MessageViewModel, dispatch: Dispatch) {
                 SystemMessage(
                     icon = R.drawable.azure_communication_ui_chat_ic_participant_removed_filled,
                     stringResource = R.string.azure_communication_ui_chat_left_chat,
-                    substitution = viewModel.message.participants.map { it.displayName ?: "Participant" }
+                    substitution = viewModel.message.participants.map {
+                        it.displayName ?: "Participant"
+                    }
                 )
             else -> {
                 BasicText(
-                    text = "${viewModel.message.content} !TYPE NOT DETECTED!" ?: "Empty"
+                    text = "${viewModel.message.content} !TYPE NOT DETECTED!"
                 )
             }
         }

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageView.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/components/MessageView.kt
@@ -42,7 +42,6 @@ import com.azure.android.communication.ui.chat.redux.Dispatch
 import com.azure.android.communication.ui.chat.service.sdk.wrapper.ChatMessageType
 import com.jakewharton.threetenabp.AndroidThreeTen
 import com.microsoft.fluentui.persona.AvatarSize
-import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneId
 import org.threeten.bp.format.DateTimeFormatter
 
@@ -176,7 +175,7 @@ private fun BasicChatMessage(viewModel: MessageViewModel, dispatch: Dispatch) {
                     .align(alignment = Alignment.Bottom)
             ) {
                 // Display the Read Receipt
-                androidx.compose.animation.AnimatedVisibility(visible = viewModel.isRead) {
+                androidx.compose.animation.AnimatedVisibility(visible = viewModel.showReadReceipt) {
                     Icon(
                         painter =
                         painterResource(
@@ -268,7 +267,7 @@ internal fun PreviewChatCompositeMessage() {
         val vms = MOCK_MESSAGES.toViewModelList(
             LocalContext.current,
             MOCK_LOCAL_USER_ID,
-            OffsetDateTime.now(),
+            0L,
             mutableSetOf()
         )
         for (a in 0 until vms.size) {

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/ChatScreenViewModel.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/ChatScreenViewModel.kt
@@ -5,7 +5,6 @@ package com.azure.android.communication.ui.chat.presentation.ui.viewmodel
 
 import android.content.Context
 import com.azure.android.communication.ui.chat.models.ChatCompositeErrorEvent
-import com.azure.android.communication.ui.chat.models.EMPTY_MESSAGE_INFO_MODEL
 import com.azure.android.communication.ui.chat.models.MessageContextMenuModel
 import com.azure.android.communication.ui.chat.models.MessageInfoModel
 import com.azure.android.communication.ui.chat.models.RemoteParticipantInfoModel
@@ -15,7 +14,9 @@ import com.azure.android.communication.ui.chat.redux.action.Action
 import com.azure.android.communication.ui.chat.redux.state.ChatStatus
 import com.azure.android.communication.ui.chat.redux.state.NavigationStatus
 import com.azure.android.communication.ui.chat.redux.state.ReduxState
+import com.azure.android.communication.ui.chat.service.sdk.wrapper.ChatMessageType
 import com.azure.android.communication.ui.chat.utilities.findMessageIdxById
+import org.threeten.bp.OffsetDateTime
 
 // View Model for the Chat Screen
 internal data class ChatScreenViewModel(
@@ -51,11 +52,16 @@ internal fun buildChatScreenViewModel(
     dispatch: Dispatch,
 ): ChatScreenViewModel {
 
+    val lastMessageIdReadByRemoteParticipants = getLastMessageIdReadByRemoteParticipants(
+        messages,
+        store.getCurrentState().participantState.latestReadMessageTimestamp
+    )
+
     return ChatScreenViewModel(
         messages = messages.toViewModelList(
             context,
             localUserIdentifier,
-            store.getCurrentState().participantState.latestReadMessageTimestamp,
+            lastMessageIdReadByRemoteParticipants,
             store.getCurrentState().participantState.hiddenParticipant
         ),
         areMessagesLoading = !store.getCurrentState().chatState.chatInfoModel.allMessagesFetched,
@@ -68,10 +74,27 @@ internal fun buildChatScreenViewModel(
         participants = store.getCurrentState().participantState.participants,
         chatTopic = store.getCurrentState().chatState.chatInfoModel.topic,
         navigationStatus = store.getCurrentState().navigationState.navigationStatus,
-        messageContextMenu = store.getCurrentState().chatState.messageContextMenu ?: MessageContextMenuModel(messageInfoModel = EMPTY_MESSAGE_INFO_MODEL, emptyList()),
+        messageContextMenu = store.getCurrentState().chatState.messageContextMenu,
         sendMessageEnabled = store.getCurrentState().participantState.localParticipantInfoModel.isActiveChatThreadParticipant &&
             store.getCurrentState().chatState.chatStatus == ChatStatus.INITIALIZED,
     )
+}
+
+private fun getLastMessageIdReadByRemoteParticipants(
+    messages: List<MessageInfoModel>,
+    latestReadMessageTimestamp: OffsetDateTime,
+): Long {
+    messages.asReversed().forEach {
+        if ((it.messageType == ChatMessageType.TEXT || it.messageType == ChatMessageType.HTML) &&
+            it.isCurrentUser
+        ) {
+            val currentMessageTime = it.editedOn ?: it.createdOn
+            if (currentMessageTime != null && currentMessageTime <= latestReadMessageTimestamp) {
+                return it.normalizedID
+            }
+        }
+    }
+    return 0
 }
 
 private fun getUnReadMessagesCount(


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* get read receipts working (removing local user from read receipts list, marking only one message as show to read, by default at start if timestamp is min, set all to current read action received)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

