### PR TITLE
[Chat][Bug] Add missing ellipsis at end of typing indicator

### DIFF
--- a/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
+++ b/azure-communication-ui/chat/src/main/res/values/azure_communication_ui_chat_strings.xml
@@ -11,9 +11,9 @@
     <string name="azure_communication_ui_chat_unread_new_message">1 new message</string>
     <string name="azure_communication_ui_chat_unread_new_messages">%1$s new messages</string>
     <string name="azure_communication_ui_chat_many_unread_new_messages">99+ new messages</string>
-    <string name="azure_communication_ui_chat_first_name_is_typing">%1$s is typing</string>
-    <string name="azure_communication_ui_chat_two_names_are_typing">%1$s and %2$s are typing"</string>
-    <string name="azure_communication_ui_chat_three_or_more_are_typing">%1$s, %2$s and %3$d %4$s are typing</string>
+    <string name="azure_communication_ui_chat_first_name_is_typing">%1$s is typing…</string>
+    <string name="azure_communication_ui_chat_two_names_are_typing">%1$s and %2$s are typing…"</string>
+    <string name="azure_communication_ui_chat_three_or_more_are_typing">%1$s, %2$s and %3$d %4$s are typing…</string>
     <string name="azure_communication_ui_chat_message_input_view_content_description">Message Input Field</string>
     <string name="azure_communication_ui_chat_message_send_button_content_description">Send the message %1$s</string>
     <string name="azure_communication_ui_chat_joined_chat">%1$s joined the chat</string>

--- a/azure-communication-ui/demo-app/src/chat/java/com/azure/android/communication/ui/chatdemoapp/ChatLauncherActivity.kt
+++ b/azure-communication-ui/demo-app/src/chat/java/com/azure/android/communication/ui/chatdemoapp/ChatLauncherActivity.kt
@@ -11,11 +11,13 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import android.webkit.URLUtil
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.core.view.get
 import com.azure.android.communication.ui.callingcompositedemoapp.BuildConfig
 import com.azure.android.communication.ui.callingcompositedemoapp.R
@@ -239,5 +241,11 @@ class ChatLauncherActivity : AppCompatActivity() {
         println(eventArgs.errorCode)
         showAlert("${eventArgs.cause}")
         println("====================================================================")
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val window: Window = this@ChatLauncherActivity.window
+        window.navigationBarColor = ContextCompat.getColor(this@ChatLauncherActivity, R.color.white)
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes the typing indicator not showing ... at the end of the typing indicator text (see screenshot)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open the app and join a chat thread with at least two participants
* Start typing on a remote participant



## What to Check
Verify that the following are valid
* Typing indicator should show and have an ellipses at the end of the indicator

## Screenshots
![Screenshot_1670963079](https://user-images.githubusercontent.com/43901/207437011-48a67df2-6c02-402a-8fb2-261922e9b72e.png)

