### PR TITLE
[Chat] Fix Previews in ChatScreenView, added flag to allow additional on screen debug info

### DIFF
--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/ChatScreen.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/chat/screens/ChatScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.material.Card
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.Scaffold
 import androidx.compose.material.rememberScaffoldState
@@ -45,6 +46,7 @@ import com.azure.android.communication.ui.chat.redux.action.NavigationAction
 import com.azure.android.communication.ui.chat.redux.state.ChatStatus
 import com.azure.android.communication.ui.chat.service.sdk.wrapper.CommunicationIdentifier
 import com.jakewharton.threetenabp.AndroidThreeTen
+import com.microsoft.fluentui.theme.ThemeMode
 import kotlinx.coroutines.launch
 
 @Composable
@@ -60,6 +62,7 @@ internal fun ChatScreen(
     Scaffold(
         backgroundColor = ChatCompositeTheme.colors.background,
         scaffoldState = scaffoldState,
+
         topBar = {
             if (!showActionBar) return@Scaffold
             val dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
@@ -67,7 +70,6 @@ internal fun ChatScreen(
                 viewModel.chatTopic != null -> viewModel.chatTopic
                 else -> stringResource(R.string.azure_communication_ui_chat_chat_action_bar_title)
             }
-
             val subTitle = stringResource(
                 id = R.string.azure_communication_ui_chat_count_people,
                 viewModel.participants.count()
@@ -132,6 +134,10 @@ internal fun ChatScreen(
                     }
                 }
             }
+            if (viewModel.debugOverlayText.isNotEmpty())
+                Card() {
+                    BasicText(viewModel.debugOverlayText)
+                }
         },
         bottomBar = {
 
@@ -174,7 +180,7 @@ internal fun ChatScreen(
 @Composable
 internal fun ChatScreenPreview() {
     AndroidThreeTen.init(LocalContext.current)
-    ChatCompositeTheme {
+    ChatCompositeTheme(themeMode = ThemeMode.Dark) {
         ChatScreen(
             viewModel = ChatScreenViewModel(
                 messages = MOCK_MESSAGES.toViewModelList(context = LocalContext.current, localUserIdentifier = MOCK_LOCAL_USER_ID, hiddenParticipant = mutableSetOf()),

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/ChatScreenViewModel.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/ChatScreenViewModel.kt
@@ -68,7 +68,8 @@ internal fun buildChatScreenViewModel(
             localUserIdentifier,
             latestLocalUserMessageId,
             lastMessageIdReadByRemoteParticipants,
-            store.getCurrentState().participantState.hiddenParticipant
+            store.getCurrentState().participantState.hiddenParticipant,
+            includeDebugInfo = includeDebugInfo
         ),
         areMessagesLoading = !store.getCurrentState().chatState.chatInfoModel.allMessagesFetched,
         chatStatus = store.getCurrentState().chatState.chatStatus,

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/ChatScreenViewModel.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/ChatScreenViewModel.kt
@@ -19,6 +19,9 @@ import com.azure.android.communication.ui.chat.service.sdk.wrapper.ChatMessageTy
 import com.azure.android.communication.ui.chat.utilities.findMessageIdxById
 import org.threeten.bp.OffsetDateTime
 
+// Show Debug Information on the screen
+internal const val includeDebugInfo = false
+
 // View Model for the Chat Screen
 internal data class ChatScreenViewModel(
     val typingParticipants: List<String>,
@@ -34,6 +37,7 @@ internal data class ChatScreenViewModel(
     val navigationStatus: NavigationStatus = NavigationStatus.NONE,
     val messageContextMenu: MessageContextMenuModel,
     val sendMessageEnabled: Boolean = false,
+    val debugOverlayText: String = "Test",
 ) {
     val showError get() = error != null && error.errorCode == ChatCompositeErrorCode.JOIN_FAILED
     val errorMessage get() = error?.errorCode?.toString() ?: ""
@@ -79,7 +83,14 @@ internal fun buildChatScreenViewModel(
         messageContextMenu = store.getCurrentState().chatState.messageContextMenu,
         sendMessageEnabled = store.getCurrentState().participantState.localParticipantInfoModel.isActiveChatThreadParticipant &&
             store.getCurrentState().chatState.chatStatus == ChatStatus.INITIALIZED,
+        debugOverlayText = getDebugOverlayText(store, messages)
     )
+}
+
+internal fun getDebugOverlayText(store: AppStore<ReduxState>, messages: List<MessageInfoModel>): String {
+    if (!includeDebugInfo) return ""
+    return "Last Read ID: ${store.getCurrentState().chatState.lastReadMessageId}\n" +
+        "Last Received Message: ${ if (messages.isEmpty()) "None" else messages.last().normalizedID }"
 }
 
 private fun getLastMessageIdReadByRemoteParticipants(

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/MessageViewModel.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/presentation/ui/viewmodel/MessageViewModel.kt
@@ -29,6 +29,7 @@ internal class MessageViewModel(
     val showSentStatusIcon: Boolean,
     val showReadReceipt: Boolean,
     val isHiddenUser: Boolean,
+    val includeDebugInfo: Boolean,
 ) {
     val isVisible get() = message.deletedOn == null && !isHiddenUser
 }
@@ -39,6 +40,7 @@ internal fun List<MessageInfoModel>.toViewModelList(
     latestLocalUserMessageId: Long? = null,
     lastMessageIdReadByRemoteParticipants: Long = 0L,
     hiddenParticipant: Set<String>,
+    includeDebugInfo: Boolean = false,
 ) =
     InfoModelToViewModelAdapter(
         context,
@@ -47,6 +49,7 @@ internal fun List<MessageInfoModel>.toViewModelList(
         latestLocalUserMessageId,
         lastMessageIdReadByRemoteParticipants,
         hiddenParticipant,
+        includeDebugInfo
     ) as List<MessageViewModel>
 
 private class InfoModelToViewModelAdapter(
@@ -56,6 +59,7 @@ private class InfoModelToViewModelAdapter(
     private val latestLocalUserMessageId: Long?,
     private val lastMessageIdReadByRemoteParticipants: Long,
     private val hiddenParticipant: Set<String>,
+    private val includeDebugInfo: Boolean = false,
 ) :
     List<MessageViewModel> {
 
@@ -76,6 +80,7 @@ private class InfoModelToViewModelAdapter(
         return MessageViewModel(
 
             thisMessage,
+            includeDebugInfo = includeDebugInfo,
             showUsername = !isLocalUser &&
                 (lastMessage.senderCommunicationIdentifier?.id ?: "")
                 != (thisMessage.senderCommunicationIdentifier?.id ?: ""),
@@ -96,7 +101,8 @@ private class InfoModelToViewModelAdapter(
             showSentStatusIcon = shouldShowMessageStatusIcon(thisMessage, showReadReceipt),
             isHiddenUser = messages[index].messageType == ChatMessageType.PARTICIPANT_ADDED &&
                 messages[index].participants.size == 1 &&
-                hiddenParticipant.contains(messages[index].participants.first().userIdentifier.id)
+                hiddenParticipant.contains(messages[index].participants.first().userIdentifier.id),
+
         )
     }
 

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/preview/PreviewData.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/preview/PreviewData.kt
@@ -28,7 +28,7 @@ internal val MOCK_MESSAGES
                 senderDisplayName = userA_Display,
                 content = "I'll message in 2 weeks",
                 messageType = ChatMessageType.TEXT,
-                id = null,
+                id = "1",
                 internalId = null,
                 createdOn = OffsetDateTime.now().minusWeeks(2).minusMinutes(10)
             ),
@@ -37,7 +37,7 @@ internal val MOCK_MESSAGES
                 senderDisplayName = userA_Display,
                 content = "Hey!!",
                 messageType = ChatMessageType.TEXT,
-                id = null,
+                id = "2",
                 internalId = null,
                 createdOn = OffsetDateTime.now().minusDays(2).minusMinutes(10)
             ),
@@ -47,7 +47,7 @@ internal val MOCK_MESSAGES
                 senderDisplayName = userB_Display,
                 content = "Hi Peter, thanks for following up with me",
                 messageType = ChatMessageType.TEXT,
-                id = OffsetDateTime.now().toEpochSecond().toString(),
+                id = "3",
                 internalId = null,
                 createdOn = OffsetDateTime.now().minusDays(1).minusMinutes(12)
             ),
@@ -57,7 +57,7 @@ internal val MOCK_MESSAGES
                 senderDisplayName = userB_Display,
                 content = "I like to type",
                 messageType = ChatMessageType.TEXT,
-                id = null,
+                id = "4",
                 internalId = null,
                 createdOn = OffsetDateTime.now().minusDays(1).minusMinutes(11)
             ),
@@ -67,7 +67,7 @@ internal val MOCK_MESSAGES
                 senderDisplayName = userB_Display,
                 content = "a lot",
                 messageType = ChatMessageType.TEXT,
-                id = null,
+                id = "5",
                 internalId = null,
                 createdOn = OffsetDateTime.now().minusDays(1).minusMinutes(10)
             ),
@@ -81,7 +81,7 @@ internal val MOCK_MESSAGES
                     RemoteParticipantInfoModel(CommunicationIdentifier.UnknownIdentifier(""), userA_Display)
                 ),
                 senderDisplayName = null,
-                id = null,
+                id = "6",
                 internalId = null,
                 createdOn = OffsetDateTime.now().minusDays(1).minusMinutes(10)
             ),
@@ -90,7 +90,7 @@ internal val MOCK_MESSAGES
                 senderDisplayName = userA_Display,
                 content = "No Problem",
                 messageType = ChatMessageType.TEXT,
-                id = null,
+                id = "7",
                 internalId = null,
                 createdOn = OffsetDateTime.now().minusMinutes(20)
             ),
@@ -100,7 +100,7 @@ internal val MOCK_MESSAGES
                 senderCommunicationIdentifier = userD_ID,
                 senderDisplayName = null,
                 participants = listOf(RemoteParticipantInfoModel(CommunicationIdentifier.UnknownIdentifier(""), userD_Display)),
-                id = null,
+                id = "8",
                 internalId = null,
                 createdOn = OffsetDateTime.now().minusMinutes(10)
             ),
@@ -109,7 +109,7 @@ internal val MOCK_MESSAGES
                 senderDisplayName = userA_Display,
                 content = "Let's work through the feedback we received on our wednesday meeting",
                 messageType = ChatMessageType.TEXT,
-                id = null,
+                id = "9",
                 internalId = null,
                 createdOn = OffsetDateTime.now().minusMinutes(5)
             ),
@@ -119,7 +119,7 @@ internal val MOCK_MESSAGES
                 senderDisplayName = userA_Display,
                 content = "<B> Hey!! </B> Check this link <A href=\"https://www.microsoft.com\">microsoft</A>",
                 messageType = ChatMessageType.HTML,
-                id = null,
+                id = "10",
                 internalId = null,
                 createdOn = OffsetDateTime.now()
             ),
@@ -127,7 +127,7 @@ internal val MOCK_MESSAGES
 
                 messageType = ChatMessageType.PARTICIPANT_REMOVED,
                 isCurrentUser = true,
-                id = null,
+                id = "11",
                 internalId = null,
                 createdOn = OffsetDateTime.now()
             ),


### PR DESCRIPTION
Add option to display text in an overlay for debug (must enable in code, includeDebugInfo in ChatScreenViewmodel)

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
