### PR TITLE
[Chat][Bug]Fix the crash when network is  disconnected. 

### DIFF
--- a/azure-communication-ui/chat/src/androidTest/java/com/azure/android/communication/ui/chat/mocking/TestChatSDK.kt
+++ b/azure-communication-ui/chat/src/androidTest/java/com/azure/android/communication/ui/chat/mocking/TestChatSDK.kt
@@ -35,12 +35,18 @@ internal class TestChatSDK(
         chatStatusStateFlow.value = status
     }
 
-    override fun initialization() {
+    override fun initialization(): CompletableFuture<Void> {
+        val future = CompletableFuture<Void>()
+        // coroutine to make sure requests are not blocking
+        coroutineScope.launch {
+            future.complete(null)
+        }
+        return future
     }
 
     override fun destroy() {}
 
-    override fun getAdminUserId(): String? {
+    override fun getAdminUserId(): String {
         return ""
     }
 

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/service/sdk/ChatSDK.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/service/sdk/ChatSDK.kt
@@ -15,9 +15,9 @@ import kotlinx.coroutines.flow.StateFlow
 import org.threeten.bp.OffsetDateTime
 
 internal interface ChatSDK {
-    fun initialization()
+    fun initialization(): CompletableFuture<Void>
     fun destroy()
-    fun getAdminUserId(): String?
+    fun getAdminUserId(): String
     fun requestPreviousPage()
     fun requestChatParticipants()
 

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/service/sdk/ChatSDKWrapper.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/service/sdk/ChatSDKWrapper.kt
@@ -74,7 +74,7 @@ internal class ChatSDKWrapper(
 
     private val options = ListChatMessagesOptions().apply { maxPageSize = PAGE_MESSAGES_SIZE }
     private var pagingContinuationToken: String? = null
-    var adminUersId: String = ""
+    private var adminUserId: String = ""
 
     @Volatile
     private var allPagesFetched: Boolean = false
@@ -110,7 +110,7 @@ internal class ChatSDKWrapper(
                 )
             )
 
-            adminUersId = threadClient.properties.createdByCommunicationIdentifier.into().id
+            adminUserId = threadClient.properties.createdByCommunicationIdentifier.into().id
             chatStatusStateFlow.value = ChatStatus.INITIALIZED
             future.complete(null)
         } catch (ex: Exception) {
@@ -129,7 +129,7 @@ internal class ChatSDKWrapper(
     }
 
     override fun getAdminUserId(): String {
-        return adminUersId
+        return adminUserId
     }
 
     override fun requestPreviousPage() {

--- a/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/service/sdk/ChatSDKWrapper.kt
+++ b/azure-communication-ui/chat/src/main/java/com/azure/android/communication/ui/chat/service/sdk/ChatSDKWrapper.kt
@@ -74,6 +74,7 @@ internal class ChatSDKWrapper(
 
     private val options = ListChatMessagesOptions().apply { maxPageSize = PAGE_MESSAGES_SIZE }
     private var pagingContinuationToken: String? = null
+    var adminUersId: String = ""
 
     @Volatile
     private var allPagesFetched: Boolean = false
@@ -90,24 +91,33 @@ internal class ChatSDKWrapper(
     override fun getChatEventSharedFlow(): SharedFlow<ChatEventModel> =
         chatEventModelSharedFlow
 
-    override fun initialization() {
-        chatStatusStateFlow.value = ChatStatus.INITIALIZATION
-        createChatClient()
-        createChatThreadClient()
-        // TODO: initialize polling or try to get first message here to make sure SDK can establish connection with thread
-        // TODO: above will make sure, network is connected as well
-        onChatEventReceived(
-            infoModel = ChatEventModel(
-                eventType = ChatEventType.CHAT_THREAD_PROPERTIES_UPDATED,
-                ChatThreadInfoModel(
-                    topic = threadClient.properties.topic,
-                    receivedOn = threadClient.properties.createdOn
-                ),
-                eventReceivedOffsetDateTime = null
+    override fun initialization(): CompletableFuture<Void> {
+        val future = CompletableFuture<Void>()
+        try {
+            chatStatusStateFlow.value = ChatStatus.INITIALIZATION
+            createChatClient()
+            createChatThreadClient()
+            // TODO: initialize polling or try to get first message here to make sure SDK can establish connection with thread
+            // TODO: above will make sure, network is connected as well
+            onChatEventReceived(
+                infoModel = ChatEventModel(
+                    eventType = ChatEventType.CHAT_THREAD_PROPERTIES_UPDATED,
+                    ChatThreadInfoModel(
+                        topic = threadClient.properties.topic,
+                        receivedOn = threadClient.properties.createdOn
+                    ),
+                    eventReceivedOffsetDateTime = null
+                )
             )
-        )
 
-        chatStatusStateFlow.value = ChatStatus.INITIALIZED
+            adminUersId = threadClient.properties.createdByCommunicationIdentifier.into().id
+            chatStatusStateFlow.value = ChatStatus.INITIALIZED
+            future.complete(null)
+        } catch (ex: Exception) {
+            future.completeExceptionally(ex)
+            logger.debug("sendMessage failed.", ex)
+        }
+        return future
     }
 
     override fun destroy() {
@@ -118,9 +128,8 @@ internal class ChatSDKWrapper(
         chatFetchNotificationHandler.stop()
     }
 
-    override fun getAdminUserId(): String? {
-        if (!this::threadClient.isInitialized) return null
-        return threadClient.properties.createdByCommunicationIdentifier.into().id
+    override fun getAdminUserId(): String {
+        return adminUersId
     }
 
     override fun requestPreviousPage() {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Request the adminUserId only when we first do initialization. Because threadClient.properties will have null pointer error when network disconnected, and crash. Already create the bug for chatSDK. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
