### PR TITLE
[Calling][Bug] skip setup should call call service call end when state is conencted

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingFragment.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingFragment.kt
@@ -77,8 +77,7 @@ internal class CallingFragment :
         confirmLeaveOverlayView.layoutDirection =
             activity?.window?.decorView?.layoutDirection ?: LayoutDirection.LOCALE
         confirmLeaveOverlayView.start(
-            viewLifecycleOwner,
-            holder.container.appStore.getCurrentState().callState
+            viewLifecycleOwner
         )
 
         controlBarView = view.findViewById(R.id.azure_communication_ui_call_call_buttons)

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmView.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.azure.android.communication.ui.R
-import com.azure.android.communication.ui.calling.redux.state.CallingState
 import com.azure.android.communication.ui.calling.utilities.BottomCellAdapter
 import com.azure.android.communication.ui.calling.utilities.BottomCellItem
 import com.azure.android.communication.ui.calling.utilities.BottomCellItemType
@@ -32,7 +31,6 @@ internal class LeaveConfirmView(
     private var leaveConfirmMenuTable: RecyclerView
     private lateinit var leaveConfirmMenuDrawer: DrawerDialog
     private lateinit var bottomCellAdapter: BottomCellAdapter
-    private lateinit var callingState: CallingState
 
     init {
         inflate(context, R.layout.azure_communication_ui_calling_listview, this)
@@ -50,10 +48,8 @@ internal class LeaveConfirmView(
     }
 
     fun start(
-        viewLifecycleOwner: LifecycleOwner,
-        callingState: CallingState
+        viewLifecycleOwner: LifecycleOwner
     ) {
-        this.callingState = callingState
         bottomCellAdapter = BottomCellAdapter()
         bottomCellAdapter.setBottomCellItems(bottomCellItems)
         leaveConfirmMenuTable.adapter = bottomCellAdapter
@@ -120,7 +116,7 @@ internal class LeaveConfirmView(
                     null,
                     false,
                 ) {
-                    viewModel.confirm(callingState)
+                    viewModel.confirm()
                 },
 
                 // Cancel

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmViewModel.kt
@@ -3,16 +3,17 @@
 
 package com.azure.android.communication.ui.calling.presentation.fragment.calling.hangup
 
+import com.azure.android.communication.ui.calling.redux.Store
 import com.azure.android.communication.ui.calling.redux.action.Action
 import com.azure.android.communication.ui.calling.redux.action.CallingAction
 import com.azure.android.communication.ui.calling.redux.action.NavigationAction
-import com.azure.android.communication.ui.calling.redux.state.CallingState
 import com.azure.android.communication.ui.calling.redux.state.CallingStatus
 import com.azure.android.communication.ui.calling.redux.state.OperationStatus
+import com.azure.android.communication.ui.calling.redux.state.ReduxState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-internal class LeaveConfirmViewModel(private val dispatch: (Action) -> Unit) {
+internal class LeaveConfirmViewModel(private val store: Store<ReduxState>) {
     private val shouldDisplayLeaveConfirmMutableStateFlow = MutableStateFlow(false)
     var shouldDisplayLeaveConfirmStateFlow = shouldDisplayLeaveConfirmMutableStateFlow as StateFlow<Boolean>
 
@@ -20,9 +21,9 @@ internal class LeaveConfirmViewModel(private val dispatch: (Action) -> Unit) {
         return shouldDisplayLeaveConfirmStateFlow
     }
 
-    fun confirm(callingState: CallingState) {
-        if (callingState.operationStatus == OperationStatus.SKIP_SETUP_SCREEN &&
-            callingState.callingStatus != CallingStatus.CONNECTED
+    fun confirm() {
+        if (store.getCurrentState().callState.operationStatus == OperationStatus.SKIP_SETUP_SCREEN &&
+            store.getCurrentState().callState.callingStatus != CallingStatus.CONNECTED
         ) {
             dispatchAction(action = NavigationAction.Exit())
         } else {
@@ -39,6 +40,6 @@ internal class LeaveConfirmViewModel(private val dispatch: (Action) -> Unit) {
     }
 
     private fun dispatchAction(action: Action) {
-        dispatch(action)
+        store.dispatch(action)
     }
 }

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/factories/CallingViewModelFactory.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/factories/CallingViewModelFactory.kt
@@ -48,7 +48,7 @@ internal class CallingViewModelFactory(
     }
 
     val confirmLeaveOverlayViewModel by lazy {
-        LeaveConfirmViewModel(store::dispatch)
+        LeaveConfirmViewModel(store)
     }
 
     val localParticipantViewModel by lazy {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Currently, the call state is always none in leave confirm view. Fixing state to get right value from redux

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [x] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [x] Unit Tests Included
  - [ ] UI Automated Tests Included
