### PR TITLE
[Calling][Bug] on activity force exit rejoin fails with call agent can not be created

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/di/DependencyInjectionContainer.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/di/DependencyInjectionContainer.kt
@@ -27,6 +27,7 @@ import com.azure.android.communication.ui.calling.redux.state.ReduxState
 import com.azure.android.communication.ui.calling.presentation.manager.DebugInfoManager
 import com.azure.android.communication.ui.calling.service.CallHistoryService
 import com.azure.android.communication.ui.calling.service.NotificationService
+import com.azure.android.communication.ui.calling.service.sdk.CallingSDK
 
 // Dependency Container for the Call Composite Activity
 // For implementation
@@ -39,6 +40,7 @@ internal interface DependencyInjectionContainer {
     val callingMiddlewareActionHandler: CallingMiddlewareActionHandler
 
     val callComposite: CallComposite
+    val callingSDKWrapper: CallingSDK
 
     // Config
     val configuration: CallCompositeConfiguration

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/di/DependencyInjectionContainerImpl.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/di/DependencyInjectionContainerImpl.kt
@@ -244,7 +244,7 @@ internal class DependencyInjectionContainerImpl(
 
     override val logger: Logger by lazy { DefaultLogger() }
 
-    private val callingSDKWrapper: CallingSDK by lazy {
+    override val callingSDKWrapper: CallingSDK by lazy {
         customCallingSDK
             ?: CallingSDKWrapper(
                 applicationContext,

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/CallCompositeActivity.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/CallCompositeActivity.kt
@@ -67,6 +67,7 @@ internal class CallCompositeActivity : AppCompatActivity() {
     private val instanceId get() = intent.getIntExtra(KEY_INSTANCE_ID, -1)
     private val callHistoryService get() = container.callHistoryService
     private val compositeManager get() = container.compositeExitManager
+    private val callingSDKWrapper get() = container.callingSDKWrapper
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -162,6 +163,8 @@ internal class CallCompositeActivity : AppCompatActivity() {
             audioModeManager.onDestroy()
             if (isFinishing) {
                 store.dispatch(CallingAction.CallEndRequested())
+                notificationService.removeNotification()
+                callingSDKWrapper.dispose()
                 compositeManager.onCompositeDestroy()
                 CallCompositeInstanceManager.removeCallComposite(instanceId)
             }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* on activity force exit rejoin fails with call agent can not be created

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included
