### PR TITLE
memory leak in rotation/recreation due to back pressed handlers

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingFragment.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingFragment.kt
@@ -14,6 +14,7 @@ import android.os.PowerManager
 import android.util.LayoutDirection
 import android.view.View
 import android.view.accessibility.AccessibilityManager
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -44,6 +45,8 @@ internal class CallingFragment :
         private const val AUDIO_DEVICE_LIST_VIEW_KEY = "AudioDeviceListView"
         private const val PARTICIPANT_LIST_VIEW_KEY = "ParticipantListView"
     }
+
+    private lateinit var backPressedCallback: OnBackPressedCallback
 
     // Get the DI Container, which gives us what we need for this fragment (dependencies)
     private val holder: DependencyInjectionContainerHolder by activityViewModels()
@@ -168,10 +171,12 @@ internal class CallingFragment :
             }
         }
 
-        requireActivity().onBackPressedDispatcher.addCallback {
+        backPressedCallback = requireActivity().onBackPressedDispatcher.addCallback {
             onBackPressed()
         }
+
     }
+
 
     private fun onBackPressed() {
         if (viewModel.multitaskingEnabled) {
@@ -210,6 +215,7 @@ internal class CallingFragment :
 
     override fun onDestroy() {
         super.onDestroy()
+        backPressedCallback.remove()
         if (activity?.isChangingConfigurations == false) {
             if (this::participantGridView.isInitialized) participantGridView.stop()
             if (CallCompositeInstanceManager.hasCallComposite(holder.instanceId)) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* onBackHandlers aren't removed when fragments were destroyed, leading to leak canary beeping a lot.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
