### PR TITLE
[Calling][API] Make fromString public for CallCompositeSetParticipantViewDataResult

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeSetParticipantViewDataResult.java
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeSetParticipantViewDataResult.java
@@ -28,17 +28,17 @@ public final class CallCompositeSetParticipantViewDataResult
             = fromString("participantNotInCall");
 
     /**
-     * Creates or finds a CallCompositeSetParticipantViewDataResult from it's string representation.
+     * Creates or finds a {@link CallCompositeSetParticipantViewDataResult} from it's string representation.
      *
      * @param name a name to look for.
-     * @return the corresponding CallCompositeSetParticipantViewDataResult.
+     * @return the corresponding {@link CallCompositeSetParticipantViewDataResult}.
      */
-    private static CallCompositeSetParticipantViewDataResult fromString(final String name) {
+    public static CallCompositeSetParticipantViewDataResult fromString(final String name) {
         return fromString(name, CallCompositeSetParticipantViewDataResult.class);
     }
 
     /**
-     * @return known CallCompositeSetParticipantViewDataResult values.
+     * @return known {@link CallCompositeSetParticipantViewDataResult} values.
      */
     public static Collection<CallCompositeSetParticipantViewDataResult> values() {
         return values(CallCompositeSetParticipantViewDataResult.class);


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Make fromString public for CallCompositeSetParticipantViewDataResult

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
