### PR TITLE
[Talkback] Toast notification reads content when is initially displayed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.aar
 *.ap_
 *.aab
+*.json
 
 # Files for the ART/Dalvik VM
 *.dex

--- a/azure-communication-ui/build.gradle
+++ b/azure-communication-ui/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        call_library_version_name = '1.4.0'
+        call_library_version_name = '1.5.0'
         chat_library_version_name = '1.0.0-beta.2'
 
         ui_library_version_code = getVersionCode()

--- a/azure-communication-ui/calling/README.md
+++ b/azure-communication-ui/calling/README.md
@@ -4,7 +4,7 @@
 
 ## Latest Release
 
-- [1.4.0 release](https://github.com/Azure/communication-ui-library-android/releases/tag/calling-v1.4.0)
+- [1.5.0 release](https://github.com/Azure/communication-ui-library-android/releases/tag/calling-v1.5.0)
 
 ## Getting Started
 
@@ -27,7 +27,7 @@ android {
 ```groovy
 dependencies {
     ...
-    implementation 'com.azure.android:azure-communication-ui-calling:1.4.0'
+    implementation 'com.azure.android:azure-communication-ui-calling:1.5.0'
     ...
 }
 ```

--- a/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/Utils.kt
+++ b/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/Utils.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import junit.framework.AssertionFailedError
 import org.hamcrest.Matchers
 
@@ -35,6 +36,14 @@ internal fun assertNotDisplayed(id: Int): ViewInteraction? {
             ViewMatchers.withId(id)
         )
     ).check(doesNotExist())
+}
+
+internal fun assertViewGone(id: Int): ViewInteraction? {
+    return Espresso.onView(
+        Matchers.allOf(
+            ViewMatchers.withId(id)
+        )
+    ).check(ViewAssertions.matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)))
 }
 
 internal fun assertViewText(id: Int, text: String) {

--- a/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/ui/calling/ToastNotificationTest.kt
+++ b/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/ui/calling/ToastNotificationTest.kt
@@ -5,6 +5,7 @@ package com.azure.android.communication.ui.calling
 
 import com.azure.android.communication.BaseUiTest
 import com.azure.android.communication.assertDisplayed
+import com.azure.android.communication.assertViewGone
 import com.azure.android.communication.assertViewText
 import com.azure.android.communication.ui.R
 import com.azure.android.communication.tapWhenDisplayed
@@ -35,9 +36,8 @@ internal class ToastNotificationTest : BaseUiTest() {
         callingSDK.setLowNetworkRecieveQuality(false)
 
         // Assert toast notification is still shown even after UFD is set to false
-        assertDisplayed(toastNotificationId)
-        assertDisplayed(toastNotificationIconId)
-        assertViewText(toastNotificationMessageId, R.string.azure_communication_ui_calling_diagnostics_network_quality_low)
+        assertViewGone(toastNotificationId)
+        assertViewGone(toastNotificationIconId)
     }
 
     @Test
@@ -62,9 +62,8 @@ internal class ToastNotificationTest : BaseUiTest() {
         callingSDK.setLowNetworkSendQuality(false)
 
         // Assert toast notification is still shown even after UFD is set to false
-        assertDisplayed(toastNotificationId)
-        assertDisplayed(toastNotificationIconId)
-        assertViewText(toastNotificationMessageId, R.string.azure_communication_ui_calling_diagnostics_network_quality_low)
+        assertViewGone(toastNotificationId)
+        assertViewGone(toastNotificationIconId)
     }
 
     @Test
@@ -90,9 +89,8 @@ internal class ToastNotificationTest : BaseUiTest() {
         callingSDK.setLowNetworkReconnectionQuality(false)
 
         // Assert toast notification is still shown even after UFD is set to false
-        assertDisplayed(toastNotificationId)
-        assertDisplayed(toastNotificationIconId)
-        assertViewText(toastNotificationMessageId, R.string.azure_communication_ui_calling_diagnostics_network_reconnecting)
+        assertViewGone(toastNotificationId)
+        assertViewGone(toastNotificationIconId)
     }
 
     @Test
@@ -174,9 +172,8 @@ internal class ToastNotificationTest : BaseUiTest() {
         callingSDK.setSpeakingWhileMuted(false)
 
         // Assert toast notification is still shown even after UFD is set to false
-        assertDisplayed(toastNotificationId)
-        assertDisplayed(toastNotificationIconId)
-        assertViewText(toastNotificationMessageId, R.string.azure_communication_ui_calling_diagnostics_you_are_muted)
+        assertViewGone(toastNotificationId)
+        assertViewGone(toastNotificationIconId)
     }
 
     @Test

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/DiagnosticConfig.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/DiagnosticConfig.kt
@@ -7,7 +7,7 @@ internal class DiagnosticConfig {
     val tags: Array<String> by lazy { arrayOf(getApplicationId()) }
 
     private fun getApplicationId(): String {
-        val callingCompositeVersionName = "1.4.0"
+        val callingCompositeVersionName = "1.5.0"
         val baseTag = "ac"
         // Tag template is: acXYYY/<version>
         // Where:

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/ToastNotificationView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/ToastNotificationView.kt
@@ -6,6 +6,8 @@ package com.azure.android.communication.ui.calling.presentation.fragment.calling
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -43,11 +45,12 @@ internal class ToastNotificationView : ConstraintLayout {
     ) {
         this.toastNotificationViewModel = toastNotificationViewModel
         viewLifecycleOwner.lifecycleScope.launch {
-            if (accessibilityEnabled) {
-                toastNotificationLayout.visibility = View.VISIBLE
-            } else {
-                toastNotificationViewModel.getDisplayToastNotificationFlow().collect {
-                    toastNotificationLayout.visibility = if (it) View.VISIBLE else View.GONE
+            toastNotificationViewModel.getDisplayToastNotificationFlow().collect {
+                toastNotificationLayout.visibility = if (it) View.VISIBLE else View.GONE
+
+                if (accessibilityEnabled && it) {
+                    toastNotificationLayout.performAccessibilityAction(AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS, null)
+                    toastNotificationLayout.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_SELECTED)
                 }
             }
         }

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/ToastNotificationViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/ToastNotificationViewModel.kt
@@ -145,8 +145,8 @@ internal class ToastNotificationViewModel(private val dispatch: (Action) -> Unit
 
     private fun displayToastNotification(toastNotificationModel: ToastNotificationModel, autoDismiss: Boolean = true) {
         if (!isPersistentNotificationDisplayed) {
-            displayToastNotificationFlow.value = true
             toastNotificationModelMessageFlow.value = toastNotificationModel
+            displayToastNotificationFlow.value = true
             if (autoDismiss) {
                 timer = Timer()
                 timer.schedule(

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/service/calling/DiagnosticConfigUnitTests.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/service/calling/DiagnosticConfigUnitTests.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 
 internal class DiagnosticConfigUnitTests {
     private val expectedPrefix = "aca110/"
-    private val expectedVersion = "${expectedPrefix}1.4.0"
+    private val expectedVersion = "${expectedPrefix}1.5.0"
 
     @Test
     fun test_Expected_Tag() {

--- a/docs/CHANGELOG_UI_CALLING.md
+++ b/docs/CHANGELOG_UI_CALLING.md
@@ -1,6 +1,6 @@
 # Azure Communication UI Calling Release History
 
-## Upcoming
+## 1.5.0 (2023-11-15)
 
 ### Features
 - Display Call Diagnostics.


### PR DESCRIPTION
## Purpose
Allows the Talback accessibility service to read the content of the toast notification messages when they appear on the screen.

For example, when you are talking while you are muted, the toast will show and now the focus will be on the toast so Talkback can read out loud the content of the notification.

Previously, the user was able to read the content of the toast if they swipe and navigate through the controls list, but now also Talback reads it when the toast appears.

![image](https://github.com/Azure/communication-ui-library-android/assets/79163512/53eb4107-af5e-4bc9-b292-901508839d87)
![image](https://github.com/Azure/communication-ui-library-android/assets/79163512/86511615-3bda-4742-b9f3-3aa2a4b79e09)


## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Pull Request Type
What kind of change does this Pull Request introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

- Enable Talback accessibility service on the phone.
- Join a call.
- Start talking while the microphone is muted.
  - The "You are muted" toast shows and talback service reads the toast content when it shows.
- Disable Internet connection and return to the app.
  - The "Reconnecting..." toast shows and talkback service reads the toas content when it shows.


## Other Information
<!-- Add any other helpful information that may be needed here. -->
