### PR TITLE
[Calling][Bug] Fix the crash for empty and invalid token  

### DIFF
--- a/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/CallLauncherActivity.kt
+++ b/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/CallLauncherActivity.kt
@@ -87,19 +87,19 @@ class CallLauncherActivity : AppCompatActivity() {
             } else {
                 groupIdOrTeamsMeetingLinkText.setText(BuildConfig.GROUP_CALL_ID)
             }
-    
+
             acsTokenText.addTextChangedListener(object : TextWatcher {
                 override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
                 }
-        
+
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                     launchButton.isEnabled = !s.isNullOrEmpty()
                 }
-        
+
                 override fun afterTextChanged(s: Editable?) {
                 }
             })
-            
+
             launchButton.setOnClickListener {
                 launch()
             }
@@ -205,14 +205,14 @@ class CallLauncherActivity : AppCompatActivity() {
                 return
             }
         }
-        
+
         try {
             CommunicationTokenCredential(acsToken)
         } catch (e: Exception) {
             showAlert("Invalid token")
             return
         }
-    
+
         callLauncherViewModel.launch(
             this@CallLauncherActivity,
             acsToken,

--- a/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/CallLauncherActivity.kt
+++ b/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/CallLauncherActivity.kt
@@ -6,12 +6,15 @@ package com.azure.android.communication.ui.callingcompositedemoapp
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
+import com.azure.android.communication.common.CommunicationTokenCredential
 import com.azure.android.communication.ui.callingcompositedemoapp.databinding.ActivityCallLauncherBinding
 import com.azure.android.communication.ui.callingcompositedemoapp.features.AdditionalFeatures
 import com.azure.android.communication.ui.callingcompositedemoapp.features.FeatureFlags
@@ -64,6 +67,7 @@ class CallLauncherActivity : AppCompatActivity() {
                 acsTokenText.setText(deeplinkAcsToken)
             } else {
                 acsTokenText.setText(BuildConfig.ACS_TOKEN)
+                launchButton.isEnabled = BuildConfig.ACS_TOKEN.isNotEmpty()
             }
 
             if (!deeplinkName.isNullOrEmpty()) {
@@ -83,7 +87,19 @@ class CallLauncherActivity : AppCompatActivity() {
             } else {
                 groupIdOrTeamsMeetingLinkText.setText(BuildConfig.GROUP_CALL_ID)
             }
-
+    
+            acsTokenText.addTextChangedListener(object : TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+                }
+        
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                    launchButton.isEnabled = !s.isNullOrEmpty()
+                }
+        
+                override fun afterTextChanged(s: Editable?) {
+                }
+            })
+            
             launchButton.setOnClickListener {
                 launch()
             }
@@ -189,7 +205,14 @@ class CallLauncherActivity : AppCompatActivity() {
                 return
             }
         }
-
+        
+        try {
+            CommunicationTokenCredential(acsToken)
+        } catch (e: Exception) {
+            showAlert("Invalid token")
+            return
+        }
+    
         callLauncherViewModel.launch(
             this@CallLauncherActivity,
             acsToken,

--- a/azure-communication-ui/demo-app/src/calling/res/layout/activity_call_launcher.xml
+++ b/azure-communication-ui/demo-app/src/calling/res/layout/activity_call_launcher.xml
@@ -90,6 +90,7 @@
             android:text="@string/launch_button_text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
+            android:enabled="false"
             app:layout_constraintTop_toBottomOf="@+id/showCallHistoryButton"
             />
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Match the iOS behaviour, if the token is empty disable the launch button.
* Add the logic to check the token is valid or not before join the call to avoid the crash. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
