### PR TITLE
[Calling][Bugfix] Error message update on user being evicted from call

### DIFF
--- a/azure-communication-ui/calling/src/main/res/values-ar-rSA/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-ar-rSA/azure_communication_ui_calling_strings.xml
@@ -66,21 +66,21 @@
 
     <!--    Compliance Banner-->
     <string name="azure_communication_ui_calling_view_banner_recording_started"><b>لقد بدأ التسجيل.</b> من خلال الانضمام، فأنت
-        توافق على كتابة الحديث لهذا الاجتماع.
+        توافق على كتابة هذا الاجتماع.
          <u>نهج الخصوصية</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>يتم حفظ التسجيل.</b> تم إيقاف التسجيل.
-        <u>تعرَّف على المزيد</u></string>
+         <u>التعرّف على المزيد</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>لقد بدأ كتابة الحديث.</b> بالانضمام، أنت
-        توافق على النسخ النص لهذا الاجتماع. <u>نهج الخصوصية</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>يتم حفظ كتابة الحديث.</b> تم إيقاف
-        النسخ. <u>تعرَّف على المزيد</u></string>
+        توافق على كتابة هذا الاجتماع. <u>نهج الخصوصية</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>يتم حفظ كتابة الحديث.</b> الكتابة
+        قيد الإيقاف. <u>التعرّف على المزيد</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>لقد بدء التسجيل والنسخ
-       النصي.</b> بالانضمام، فأنت توافق على كتابة الحديث لهذا الاجتماع
+        النصي.</b> بالانضمام، فأنت توافق على كتابة الحديث لهذا الاجتماع
         . <u>نهج الخصوصية</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>يتم حفظ التسجيل والنسخ
-        النصي.</b> تم إيقاف التسجيل وكتابة الحديث. <u>تعرَّف على المزيد</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>تم إيقاف التسجيل.</b> تقوم الآن
-        بكتابة الحديث لهذا الاجتماع. <u>نهج الخصوصية</u></string>
+        النصي.</b> تم إيقاف التسجيل وكتابة الحديث. <u>التعرّف على المزيد</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>تم إيقاف التسجيل.</b> أنت
+        تكتب حديث هذا الاجتماع الآن فقط. <u>نهج الخصوصية</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>تم إيقاف كتابة الحديث.
     </b> أنت الآن تسجل هذا الاجتماع فقط. <u>نهج الخصوصية</u></string>
     <string name="azure_communication_ui_calling_view_link">رابط</string>
@@ -88,7 +88,7 @@
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">تجاهل</string>
     <string name="azure_communication_ui_calling_alert_title">تنبيه</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">تمت إزالتك من المكالمة بسبب حدوث خطأ.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">ربما تمت إزالتك من الاجتماع، أو فقدت الاتصال. حاول الانضمام مرة أخرى.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">يتعذر الانضمام إلى المكالمة بسبب حدوث خطأ.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">تمت إزالتك من المكالمة.</string>
     <string name="azure_communication_ui_calling_no_connection_available">تعذر الانضمام إلى المكالمة. تحقق من اتصال الشبكة.</string>

--- a/azure-communication-ui/calling/src/main/res/values-de-rDE/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-de-rDE/azure_communication_ui_calling_strings.xml
@@ -20,9 +20,9 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">Mikrofon ein</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">An Anruf teilnehmen</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Ihr Audio ist deaktiviert. Um es zu aktivieren, wechseln Sie zu „Einstellungen“, um den Zugriff zuzulassen. Sie müssen
- Audio aktivieren, um diesen Anruf zu starten.</string>
+        Audio aktivieren, um diesen Anruf zu starten.</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Ihre Kamera ist deaktiviert. Wechseln Sie zum Aktivieren zu „Einstellungen“
-,         um den Zugriff zuzulassen.</string>
+        , um den Zugriff zuzulassen.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Berechtigungen erforderlich</string>
     <string name="azure_communication_ui_calling_setup_view_go_to_settings">Zu „Einstellungen“ wechseln</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Ausgewählt</string>
@@ -65,30 +65,30 @@
     <string name="azure_communication_ui_calling_view_share_diagnostics_title">Diagnoseinformationen</string>
 
     <!--    Compliance Banner-->
-    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Die Transkription hat begonnen.</b> Indem Sie sich anmelden, erklären Sie
- sich damit einverstanden, dass diese Besprechung transkribiert wird.
- <u>Datenschutzrichtlinie</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>Die Aufnahme wird gespeichert.</b> Die Aufzeichnung wurde beendet.
+    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Die Aufzeichnung hat begonnen.</b> Mit Ihrer Teilnahme, erklären Sie
+        sich damit einverstanden, dass diese Besprechung transkribiert wird.
+         <u>Datenschutzrichtlinie</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>Die Aufzeichnung wird gespeichert.</b> Die Aufzeichnung wurde beendet.
          <u>Weitere Informationen</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>Die Transkription hat begonnen.</b> Indem Sie sich anmelden, erklären Sie
- sich damit einverstanden, dass dieses Treffen transkribiert wird. <u>Datenschutzrichtlinie</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>Die Transkription hat begonnen.</b> Mit Ihrer Teilnahme, erklären Sie
+        sich damit einverstanden, dass diese Besprechung transkribiert wird. <u>Datenschutzrichtlinie</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>Die Transkription wird gespeichert.</b> Die Transkription
         wurde beendet. <u>Weitere Informationen</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>Aufzeichnung und Transkription haben
-      begonnen.</b> Mit Ihrer Teilnahme erklären Sie sich damit einverstanden, dass diese Besprechung transkribiert wird
-     . <u>Datenschutzbestimmungen</u></string>
+        begonnen.</b> Mit Ihrer Teilnahme erklären Sie sich damit einverstanden, dass diese Besprechung transkribiert wird
+        . <u>Datenschutzrichtlinie</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>Aufnahme und Transkription werden
         gespeichert.</b> Aufzeichnung und Transkription wurden beendet. <u>Weitere Informationen</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>Die Aufzeichnung wurde gestoppt.</b> Sie
- transkribieren jetzt nur diese Besprechung. <u>Datenschutzbestimmungen</u></string>
+        transkribieren diese Besprechung jetzt nur noch. <u>Datenschutzrichtlinie</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>Die Transkription wurde beendet.
-    </b> Sie nehmen jetzt nur diese Besprechung auf. <u>Datenschutzrichtlinie</u></string>
+    </b> Sie zeichnen diese Besprechung jetzt nur auf. <u>Datenschutzrichtlinie</u></string>
     <string name="azure_communication_ui_calling_view_link">Link</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Schließen</string>
     <string name="azure_communication_ui_calling_alert_title">Warnung</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">Sie wurden aufgrund eines Fehlers aus dem Anruf entfernt.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">Möglicherweise wurden Sie aus der Besprechung entfernt oder Ihre Verbindung wurde unterbrochen. Versuchen Sie, erneut beizutreten.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Teilnahme am Anruf aufgrund eines Fehlers nicht möglich.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">Sie wurden aus dem Anruf entfernt.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Teilnahme am Anruf nicht möglich. Überprüfen Sie Ihre Netzwerkverbindung.</string>

--- a/azure-communication-ui/calling/src/main/res/values-en-rGB/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-en-rGB/azure_communication_ui_calling_strings.xml
@@ -88,7 +88,7 @@
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Dismiss</string>
     <string name="azure_communication_ui_calling_alert_title">Alert</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">You were removed from the call due to an error.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">You may have been removed from the meeting, or lost your connection. Try to join again.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Unable to join the call due to an error.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">You were removed from the call.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Unable to join call. Check your network connection.</string>

--- a/azure-communication-ui/calling/src/main/res/values-en-rUS/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-en-rUS/azure_communication_ui_calling_strings.xml
@@ -94,7 +94,7 @@
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Dismiss</string>
     <string name="azure_communication_ui_calling_alert_title">Alert</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">You were removed from the call due to an error.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">You may have been removed from the meeting, or lost your connection. Try to join again.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Unable to join the call due to an error.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">You were removed from the call.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Unable to join call. Check your network connection.</string>

--- a/azure-communication-ui/calling/src/main/res/values-es-rES/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-es-rES/azure_communication_ui_calling_strings.xml
@@ -66,12 +66,12 @@
 
     <!--    Compliance Banner-->
     <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Se ha iniciado la grabación.</b> Al unirse, está
-        dando su consentimiento para que se transcriba esta reunión.
-        <u>Directiva de privacidad</u></string>
+        da su consentimiento para que se transcriba esta reunión.
+         <u>Directiva de privacidad</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>La grabación se está guardando.</b> La grabación se ha detenido.
          <u>Obtener más información</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>Se ha iniciado la transcripción.</b> Al unirse, 
-        está dando su consentimiento para que se transcriba esta reunión. <u>Directiva de privacidad</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>Se ha iniciado la transcripción.</b> Al unirse,
+        da su consentimiento para que se transcriba esta reunión. <u>Directiva de privacidad</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>Se está guardando la transcripción.</b>La transcripción
         se ha detenido. <u>Obtener más información</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>La grabación y transcripción han
@@ -80,15 +80,15 @@
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>La grabación y transcripción se
         están guardando.</b> Se detuvo la grabación y transcripción. <u>Obtener más información</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>La grabación se ha detenido.</b> Ahora
-        solo está transcribiendo esta reunión. <u>Directiva de privacidad</u></string>
+        ahora solo está transcribiendo esta reunión. <u>Directiva de privacidad</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>La transcripción se ha detenido.
-    </b> Ahora solo está grabando esta reunión. <u>Directiva de privacidad</u></string>
+    </b> Solo está grabando esta reunión. <u>Directiva de privacidad</u></string>
     <string name="azure_communication_ui_calling_view_link">Vínculo</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Descartar</string>
     <string name="azure_communication_ui_calling_alert_title">Alerta</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">Se le ha quitado de la llamada debido a un error.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">Puede que se le haya eliminado de la reunión o que haya perdido la conexión. Intente unirse de nuevo.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">No se puede unir a la llamada debido a un error.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">Te han quitado de la llamada.</string>
     <string name="azure_communication_ui_calling_no_connection_available">No se puede unir a la llamada. Comprueba la conexión de red.</string>

--- a/azure-communication-ui/calling/src/main/res/values-fi-rFI/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-fi-rFI/azure_communication_ui_calling_strings.xml
@@ -19,9 +19,9 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_off">Mikrofoni ei käytössä</string>
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">Mikrofoni käytössä</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">Liity puheluun</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Ääni on poistettu käytöstä. Ota käyttöön siirtymällä Asetuksiin ja sallimalla käyttö. Sinun on
+    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Ääni on poistettu käytöstä. Ota se käyttöön siirtymällä asetuksiin ja sallimalla käyttö. Sinun on
         otettava ääni käyttöön aloittaaksesi tämän puhelun.</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Kamerasi on poistettu käytöstä. Ota käyttöön siirtymällä Asetuksiin
+    <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Kamerasi on poistettu käytöstä. Ota se käyttöön siirtymällä asetuksiin
         ja sallimalla käyttö.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Vaaditut käyttöoikeudet</string>
     <string name="azure_communication_ui_calling_setup_view_go_to_settings">Siirry asetuksiin</string>
@@ -65,30 +65,30 @@
     <string name="azure_communication_ui_calling_view_share_diagnostics_title">Diagnostiikkatiedot</string>
 
     <!--    Compliance Banner-->
-    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Tallennus on aloitettu.</b> Liittymällä annat
-        suostumuksen sille, että tämä kokous litteroidaan.
-        <u>Tietosuojakäytäntö</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Tallennus on aloitettu.</b> Liittymällä
+        annat suostumuksesi kokouksen litteroimiseen.
+         <u>Tietosuojakäytäntö</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>Tallennetta tallennetaan.</b> Tallennus on pysäytetty.
          <u>Lisätietoja</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>Litterointi on alkanut.</b> Liittymällä
-        annat suostumuksesi tämän kokouksen litteroimiseen. <u>Tietosuojakäytäntö</u></string>
+        annat suostumuksesi kokouksen litteroimiseen. <u>Tietosuojakäytäntö</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>Litterointia tallennetaan.</b> Litterointi
-        on pysäytetty. <u> Lisätietoja</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>Tallennus ja litterointi on aloitettu.
-        </b> Liittymällä annat suostumuksesi kokouksen litteroimiseen
-        .<u>Tietosuojakäytäntö</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>Tallennus ja litterointi tallennetaan
-        </b> Tallennus ja litterointi on pysäytetty. <u>Lisätietoja</u></string>
+        on pysäytetty. <u>Lisätietoja</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>Tallennus ja litterointi on
+        aloitettu.</b> Liittymällä annat suostumuksesi kokouksen litteroimiseen
+        . <u>Tietosuojakäytäntö</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>Tallennus ja litterointi
+        tallennetaan.</b> Tallennus ja litterointi on pysäytetty. <u>Lisätietoja</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>Tallennus on pysäytetty.</b> Sinä
-        litteroit nyt vain tämän kokouksen. <u>Tietosuojakäytäntö</u></string>
+        ainoastaan litteroit nyt tätä kokousta. <u>Tietosuojakäytäntö</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>Litterointi on pysäytetty.
-        </b> Olet nyt tallentamassa vain tätä kokousta.<u>Tietosuojakäytäntö</u></string>
+    </b> Sinä ainoastaan tallennat nyt tätä kokousta. <u>Tietosuojakäytäntö</u></string>
     <string name="azure_communication_ui_calling_view_link">Linkki</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Hylkää</string>
     <string name="azure_communication_ui_calling_alert_title">Ilmoitus</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">Sinut poistettiin puhelusta virheen vuoksi.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">Sinut on ehkä poistettu kokouksesta tai yhteys katkesi. Yritä liittyä uudelleen.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Puheluun liittyminen ei onnistu virheen vuoksi.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">Sinut poistettiin puhelusta.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Puheluun liittyminen ei onnistu. Tarkista verkkoyhteys.</string>

--- a/azure-communication-ui/calling/src/main/res/values-fr-rFR/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-fr-rFR/azure_communication_ui_calling_strings.xml
@@ -19,10 +19,10 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_off">Microphone désactivé</string>
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">Microphone activé</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">Rejoindre l’appel</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Votre audio est désactivé. Pour l’activer, accédez à Paramètres pour autoriser l’accès. Vous devez
-         activer l’audio pour démarrer cet appel.</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Votre caméra est désactivée. Pour l’activer, accédez à Paramètres
-        pour autoriser l’accès.</string>
+    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Votre audio est désactivé. Pour l\'activer, accédez à Paramètres pour autoriser l\'accès. Vous devez
+        activer l\'audio pour démarrer cet appel.</string>
+    <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Votre caméra est désactivée. Pour l\'activer, accédez à Paramètres
+        pour autoriser l\'accès.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Autorisations requises</string>
     <string name="azure_communication_ui_calling_setup_view_go_to_settings">Accéder aux paramètres</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Sélectionné</string>
@@ -65,30 +65,30 @@
     <string name="azure_communication_ui_calling_view_share_diagnostics_title">Informations de diagnostic</string>
 
     <!--    Compliance Banner-->
-    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>La transcription a démarré.</b> En participant, vous
+    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>L\'enregistrement a démarré.</b> En participant, vous
         autorisez la transcription de cette réunion.
-        <u>Politique de confidentialité</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>L\'enregistrement est en cours d’enregistrement.</b>L\'enregistrement s’est arrêté.
+         <u>Politique de confidentialité</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>L\'enregistrement est en cours d\'enregistrement.</b>L\'enregistrement s\'est arrêté.
          <u>En savoir plus</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>La transcription a démarré.</b> En participant, vous
         autorisez la transcription de cette réunion. <u>Politique de confidentialité</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>La transcription est en cours d’enregistrement.</b> La transcription
-        s’est arrêtée. <u>En savoir plus</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>L’enregistrement et la transcription ont
-       démarré.</b> En participant, vous autorisez la transcription de cette réunion
-         . <u>Politique de confidentialité</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>L’enregistrement et la transcription sont
-        en cours d’enregistrement.</b> L’enregistrement et la transcription se sont arrêtés. <u>En savoir plus</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>L\'enregistrement s’est arrêté.</b> Vous
-        transcrivez uniquement cette réunion à présent. <u>Politique de confidentialité</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>La transcription s’est arrêtée.
-     </b> Vous        enregistrez cette réunion uniquement à présent. <u>Politique de confidentialité</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>La transcription est en cours d\'enregistrement.</b> La transcription
+        s\'est arrêtée. <u>En savoir plus</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>L\'enregistrement et la transcription ont
+        démarré.</b> En participant, vous autorisez la transcription de cette réunion
+        . <u>Politique de confidentialité</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>L\'enregistrement et la transcription sont
+        en cours d\'enregistrement.</b> L\'enregistrement et la transcription se sont arrêtés. <u>En savoir plus</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>L\'enregistrement s\'est arrêté.</b> Vous
+        ne transcrivez que cette réunion. <u>Politique de confidentialité</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>La transcription s\'est arrêtée.
+    </b>Vous enregistrez uniquement cette réunion. <u>Politique de confidentialité</u></string>
     <string name="azure_communication_ui_calling_view_link">Lien</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Ignorer</string>
     <string name="azure_communication_ui_calling_alert_title">Alerte</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">Vous avez été supprimé de l’appel en raison d’une erreur.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">Vous avez peut-être été supprimé de la réunion ou perdu votre connexion. Réessayez de rejoindre la réunion.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Impossible de rejoindre l’appel en raison d’une erreur.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">Vous avez été retiré de l’appel.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Impossible de rejoindre l’appel. Vérifiez votre connexion réseau.</string>

--- a/azure-communication-ui/calling/src/main/res/values-it-rIT/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-it-rIT/azure_communication_ui_calling_strings.xml
@@ -19,9 +19,9 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_off">Microfono disattivato</string>
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">Microfono acceso</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">Partecipa alla chiamata</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">L\'audio è disabilitato. Per abilitaloe, vai a Impostazioni per consentire l\'accesso. È necessario
-        abilitare l\'audio per avviare questa chiamata.</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">La fotocamera è disabilitata. Per abilitarla, passare a Impostazioni
+    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">L\'audio è disabilitato. Per abilitarlo, vai a Impostazioni per consentire l\'accesso. È necessario
+        abilita l\'audio per avviare questa chiamata.</string>
+    <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">La fotocamera è disabilitata. Per abilitarla, passa a Impostazioni
         per consentire l\'accesso.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Autorizzazioni necessarie</string>
     <string name="azure_communication_ui_calling_setup_view_go_to_settings">Vai a Impostazioni</string>
@@ -66,29 +66,29 @@
 
     <!--    Compliance Banner-->
     <string name="azure_communication_ui_calling_view_banner_recording_started"><b>La registrazione è stata avviata.</b> Partecipando,
-        fornisci il consenso per la trascrizione della riunione 
+        fornisci il consenso per la trascrizione di questa riunione.
          <u>Informativa sulla privacy</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>È in corso il salvataggio della registrazione. </b> La registrazione è stata arrestata.
-         <u>Altre informazioni</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>trascrizione è stata avviata.</b> Partecipando,
-        fornisci il consenso per la trascrizione della riunione.<u>Informativa sulla privacy</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>È in corso il salvataggio della registrazione.</b> La registrazione è stata arrestata.
+         <u>Scopri di più.</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>La trascrizione è stata avviata.</b> Partecipando, 
+        fornisci il consenso per la trascrizione di questa riunione. <u>Informativa sulla privacy</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>È in corso il salvataggio della trascrizione.</b> La trascrizione
-        è stata arrestata. <u>Altre informazioni</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>Registrazione e trascrizione sono
-        avviati.</b> Partecipando, fornisci il consenso per la trascrizione della riunione.
+        è stato arrestata. <u>Scopri di più.</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>La registrazione e la trascrizione sono
+        state avviate.</b> Partecipando, fornisci il consenso per la trascrizione della riunione online
         . <u>Informativa sulla privacy</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>Registrazione e trascrizione sono
-        in fase di salvataggio.</b> La registrazione e la trascrizione sono state arrestate. <u>Altre informazioni</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>La registrazione è stata arrestata.</b>Ora
-        stai solo trascrivendo questa riunione. <u>Informativa sulla privacy</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>La registrazione e la trascrizione vengono
+        salvati.</b> La registrazione e la trascrizione sono state arrestate. <u>Scopri di più.</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>La registrazione è stata arrestata.</b> Ora
+        sta trascrivendo solo questa riunione. <u>Informativa sulla privacy</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>La trascrizione è stata arrestata.
-    </b>Ora stai solo registrando questa riunione. <u>Informativa sulla privacy</u></string>
+    </b>È in corso la registrazione solo di questa riunione. <u>Informativa sulla privacy</u></string>
     <string name="azure_communication_ui_calling_view_link">Collegamento</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Ignora</string>
     <string name="azure_communication_ui_calling_alert_title">Avviso</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">Sei stato rimosso dalla chiamata a causa di un errore.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">È possibile che tu sia stato rimosso dalla riunione o che abbia perso la connessione. Prova a partecipare di nuovo.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Impossibile partecipare alla chiamata a causa di un errore.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">Sei stato rimosso dalla chiamata.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Impossibile partecipare alla chiamata. Controlla la connessione di rete.</string>

--- a/azure-communication-ui/calling/src/main/res/values-iw-rIL/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-iw-rIL/azure_communication_ui_calling_strings.xml
@@ -19,8 +19,8 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_off">מיקרופון כבוי</string>
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">מיקרופון מופעל</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">הצטרף לשיחה</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">השמע שלך מושבת. כדי להפעיל אותו, עבור אל \'הגדרות\' כדי לאפשר גישה. עליך
-       להפעיל שמע כדי להתחיל את שיחה זו.</string>
+    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">השמע שלך מושבת. כדי להפעיל אותו, עבור אל \'הגדרות\' כדי לאפשר גישה. עליך 
+        להפעיל שמע כדי להתחיל את השיחה הזו.</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">המצלמה שלך מושבתת. כדי להפעיל אותה, עבור אל \'הגדרות\'
         כדי לאפשר גישה.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">נדרשות הרשאות</string>
@@ -71,24 +71,24 @@
     <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>ההקלטה נשמרת. </b> ההקלטה הופסקה.
          <u>מידע נוסף</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>התמלול התחיל.</b> על-ידי הצטרפות, אתה
-        נותן את הסכמתך לתמלול של פגישה זו. <u>מדיניות פרטיות</u></string>
+        נותן את הסכמתך לתעתק פגישה זו. <u>מדיניות פרטיות</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>התמלול נשמר.</b> התמלול
-        הופסק. <u>למידע נוסף</u></string>
+        הופסק. <u>מידע נוסף</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>ההקלטה והתמלול
         התחילו.</b> על-ידי הצטרפות, אתה נותן את הסכמתך לתמלול של פגישה זו
-        .<u>מדיניות פרטיות</u></string>
+        . <u>מדיניות פרטיות</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>ההקלטה והתמלול
-        נשמרים.</b> ההקלטה והתמלול הפסיקו. <u>למידע נוסף</u></string>
+        נשמרים.</b> ההקלטה והתמלול הפסיקו. <u>מידע נוסף</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>ההקלטה הופסקה.</b> אתה
-        מתעתק כעת רק את פגישה זו. <u>מדיניות הפרטיות של</u></string>
+        מתעתק עכשיו רק את הפגישה הזו. <u>מדיניות פרטיות</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>התמלול הופסק.
-    </b> אתה מתמלל כעת רק הקלטה של פגישה זו. <u>מדיניות פרטיות</u></string>
+    </b> אתה כעת רק מקליט את הפגישה. <u>מדיניות פרטיות</u></string>
     <string name="azure_communication_ui_calling_view_link">קישור</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">התעלם</string>
     <string name="azure_communication_ui_calling_alert_title">התראה</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">הוסרת מהשיחה עקב שגיאה.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">ייתכן שהוסרת מהפגישה או שהחיבור שלך אבד. נסה להצטרף שוב.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">לא ניתן להצטרף לשיחה עקב שגיאה.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">הוסרת מהשיחה.</string>
     <string name="azure_communication_ui_calling_no_connection_available">לא ניתן להצטרף לשיחה. בדוק את חיבור הרשת שלך.</string>

--- a/azure-communication-ui/calling/src/main/res/values-ja-rJP/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-ja-rJP/azure_communication_ui_calling_strings.xml
@@ -19,10 +19,10 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_off">マイク オフ</string>
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">マイク オン</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">通話に参加する</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">オーディオが無効になっています。有効にするには、[設定] に移動してアクセスを許可してください。
-        この通話を開始するには、オーディオを有効にする必要があります。</string>
+    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">オーディオが無効です。有効にするには、[設定] に移動してアクセスを許可してください。この
+       通話を開始するにはオーディオを有効にする必要があります。</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">カメラが無効になっています。有効にするには、[設定] に移動して
-        アクセスを許可してください。</string>
+       アクセスを許可してください。</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">アクセス許可が必要です</string>
     <string name="azure_communication_ui_calling_setup_view_go_to_settings">設定に移動</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">選択済み</string>
@@ -66,29 +66,29 @@
 
     <!--    Compliance Banner-->
     <string name="azure_communication_ui_calling_view_banner_recording_started"><b>レコーディングが開始されました。</b> 参加すると、
-        この会議の文字起こしが行われることに同意したことになります。
-         <u>プライバシー ポリシー</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>レコーディングを保存しています。</b> レコーディングが停止されました。
-         <u>詳細情報</u></string>
+       この会議が文字起こしされることに同意したことになります。
+        <u>プライバシー ポリシー</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>レコーディングを保存しています。</b>レコーディングが停止しました。
+        <u>詳細情報</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>文字起こしが開始されました。</b> 参加すると、
-        この会議の文字起こしが行われることに同意したことになります。<u>プライバシー ポリシー</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>トランスクリプトを保存しています。</b> 文字起こしが
-        停止しました。<u>詳細情報</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>レコーディングと文字起こしが
-        開始されました。</b> 参加すると、この会議の文字起こしが行われることに同意したことになります。
-        . <u>プライバシー ポリシー</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>レコーディングとトランスクリプトを
-        保存しています。</b> レコーディングと文字起こしが停止しました。<u>詳細情報</u></string>
+       この会議が文字起こしされることに同意したことになります。<u>プライバシー ポリシー</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>文字起こしを保存しています。</b> 文字起こしが
+       停止しました。<u>詳細情報</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>レコーディングと文字起こしが開始され
+       ました。</b>参加すると、この会議が文字起こしされることに同意したことになります
+       。<u>プライバシー ポリシー</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>レコーディングと文字起こしを保存
+       しています。</b>レコーディングと文字起こしが停止しました。<u>詳細情報</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>レコーディングが停止しました。</b>
-        この会議の文字起こしのみが行われるようになります。<u>プライバシー ポリシー</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>文字起こしが停止しました。</b>
-        この会議のレコーディングのみが行われるようになります。<u>プライバシー ポリシー</u></string>
+       現在、この会議の文字起こしのみを行っています。<u>プライバシー ポリシー</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>文字起こしが停止しました。
+   </b>現在、この会議のレコーディングのみを行っています。<u>プライバシー ポリシー</u></string>
     <string name="azure_communication_ui_calling_view_link">リンク</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">却下</string>
     <string name="azure_communication_ui_calling_alert_title">アラート</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">エラーが発生したため、通話から削除されました。</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">会議から削除されたか、接続が失われた可能性があります。もう一度参加してみてください。</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">エラーが発生したため、通話に参加できません。</string>
     <string name="azure_communication_ui_calling_call_state_evicted">通話から削除されました。</string>
     <string name="azure_communication_ui_calling_no_connection_available">通話に参加できません。ネットワーク接続を確認してください。</string>

--- a/azure-communication-ui/calling/src/main/res/values-ko-rKR/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-ko-rKR/azure_communication_ui_calling_strings.xml
@@ -65,30 +65,30 @@
     <string name="azure_communication_ui_calling_view_share_diagnostics_title">진단 정보</string>
 
     <!--    Compliance Banner-->
-    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>녹음을 시작했습니다.</b>참가하면 이 모임을 전사하는데
-       동의하게 됩니다.
-         <u>개인 정보 취급 방침</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>녹음을 저장하는 중입니다. </b> 녹음이 중지되었습니다.
+    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>녹음/녹화를 시작했습니다.</b> 참가하면
+        이 모임의 대화 내용을 기록하는 데 동의하게 됩니다.
+         <u>개인정보처리방침</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>녹음/녹화를 저장하는 중입니다. </b>녹음/녹화를 중지했습니다.
          <u>자세한 정보</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>대화 내용 기록을 시작했습니다.</b>참가하면 이 모임의 대화 내용을 기록하는데
-       동의하게 됩니다. <u>개인 정보 취급 방침</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>대화 내용 기록을 저장하는 중입니다.</b> 대화 내용 기록이
-        중지되었습니다. <u>자세한 정보</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>녹음 및 대화 내용 기록을
-        시작했습니다.</b> 참가하면 이 모임을
-        대화 내용을 기록하는데 동의하게 됩니다. <u>개인 정보 취급 방침</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>녹음 및 대화 내용 기록이 저장되고
-        있습니다.</b>녹음 및 대화 내용 기록이 중지되었습니다. <u>자세한 정보</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>녹음이 중지되었습니다.</b>이제 이 모임에서
-        전사만 합니다. <u>개인 정보 취급 방침</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>대화 내용 기록이 중지되었습니다.</b>이제 이 모임에서
-        녹음만 합니다. <u>개인 정보 취급 방침</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>대화 내용 기록을 시작했습니다.</b>참가하면
+        이 모임의 대화 내용을 기록하는 데 동의하게 됩니다. <u>개인정보처리방침</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>대화 내용 기록을 저장하는 중입니다.</b> 대화 내용 기록을
+        중지했습니다. <u>자세한 정보</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>녹음/녹화 및 대화 내용 기록을
+        시작했습니다.</b> 참가하면 이 모임의 대화 내용을 기록하는 데 동의하게 됩니다
+        . <u>개인정보처리방침</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>녹음/녹화 및 대화 내용 기록을
+        저장하는 중입니다.</b> 녹음/녹화 및 대화 내용 기록을 중지했습니다. <u>자세한 정보</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>녹음/녹화를 중지했습니다.</b>이제 이 모임의
+        대화 기록만 진행합니다. <u>개인정보처리방침</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>대화 내용 기록을 중지했습니다.
+    </b> 이제 이 모임의 녹음/녹화만 진행합니다. <u>개인정보처리방침</u></string>
     <string name="azure_communication_ui_calling_view_link">링크</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">해제</string>
     <string name="azure_communication_ui_calling_alert_title">알림</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">오류로 인해 통화에서 제외되었습니다.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">모임에서 제거되거나 연결이 끊어진 것 같습니다. 다시 시도하세요.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">오류로 인해 통화에 참가할 수 없습니다.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">통화에서 제거되었습니다.</string>
     <string name="azure_communication_ui_calling_no_connection_available">통화에 참가할 수 없습니다. 네트워크 연결을 확인하세요.</string>

--- a/azure-communication-ui/calling/src/main/res/values-nb-rNO/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-nb-rNO/azure_communication_ui_calling_strings.xml
@@ -20,9 +20,9 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">Mikrofon på</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">Bli med i samtale</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Lyden er deaktivert. Hvis du vil aktivere, kan du gå til Innstillinger for å gi tilgang. Du må
- aktivere lyd for å starte denne samtalen.</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Kameraet er deaktivert. Hvis du vil aktivere, kan du gå til Innstillinger
- for å gi tilgang.</string>
+        aktivere lyd for å starte denne samtalen.</string>
+    <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Kameraet er deaktivert. Hvis du vil aktivere, går du til Innstillinger
+        for å gi tilgang.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Tillatelser kreves</string>
     <string name="azure_communication_ui_calling_setup_view_go_to_settings">Gå til Innstillinger</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Valgt</string>
@@ -66,29 +66,29 @@
 
     <!--    Compliance Banner-->
     <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Opptak er startet.</b> Ved å bli med, gir du
- samtykke til at dette møtet transkriberes.
- <u>Personvernerklæring</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>Opptak lagres.</b> Opptak har stoppet.
- <u>Mer informasjon</u></string>
+        samtykke til at dette møtet blir transkribert.
+         <u>Personvernerklæring</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>Opptaket lagres.</b> Opptaket er stoppet.
+         <u>Mer informasjon</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>Transkripsjon har startet.</b> Ved å bli med,
-        samtykker du til at dette møtet blir transkribert. <u>Personvernerklæring</u></string>
+        gir du samtykke til at dette møtet blir transkribert. <u>Personvernerklæring</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>Transkripsjon lagres.</b> Transkripsjon
- har stoppet. <u>Mer informasjon</u></string>
+        er stoppet. <u>Mer informasjon</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>Opptak og transkripsjon har
- startet.</b> Ved å bli med gir du samtykke til at dette møtet transkriberes
- . <u>Personvernerklæring</u></string>
+        startet.</b> Ved å bli med gir du samtykke til at dette møtet transkriberes
+        . <u>Personvernerklæring</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>Opptak og transkripsjon
- lagres.</b> Opptak og transkripsjon er stoppet. <u>Mer informasjon</u></string>
+        lagres.</b> Innspilling og transkripsjon er stoppet. <u>Mer informasjon</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>Opptak er stoppet.</b> Du
- transkriberer nå bare dette møtet. <u>Personvernerklæring</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>Transkripsjon har stoppet.
- </b> Du tar nå bare opp dette møtet. <u>Personvernerklæring</u></string>
+        bare transkriberer dette møtet nå. <u>Personvernerklæring</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>Transkripsjon er stoppet.
+    </b> Du tar nå bare opp dette møtet. <u>Personvernerklæring</u></string>
     <string name="azure_communication_ui_calling_view_link">Kobling</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Lukk</string>
     <string name="azure_communication_ui_calling_alert_title">Varsel</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">Du ble fjernet fra samtalen på grunn av en feil.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">Du kan ha blitt fjernet fra møtet eller mistet tilkoblingen. Prøv å bli med på nytt.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Kan ikke bli med i samtalen på grunn av en feil.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">Du ble fjernet fra samtalen.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Kan ikke bli med i samtalen. Kontroller nettverkstilkoblingen.</string>

--- a/azure-communication-ui/calling/src/main/res/values-nl-rNL/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-nl-rNL/azure_communication_ui_calling_strings.xml
@@ -20,9 +20,9 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">Microfoon aan</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">Deelnemen aan gesprek</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Uw audio is uitgeschakeld. Als u deze wilt inschakelen, gaat u naar Instellingen om toegang toe te staan. U moet
-         audio inschakelen om dit gesprek te starten.</string>
+        audio inschakelen om dit gesprek te starten.</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Uw camera is uitgeschakeld. Als u deze wilt inschakelen, gaat u naar Instellingen
-        om toegang toe te staan.</string>
+        om toegang te verlenen.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Machtigingen vereist</string>
     <string name="azure_communication_ui_calling_setup_view_go_to_settings">Ga naar Instellingen</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Geselecteerd</string>
@@ -65,30 +65,30 @@
     <string name="azure_communication_ui_calling_view_share_diagnostics_title">Diagnostische gegevens</string>
 
     <!--    Compliance Banner-->
-    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Opname is gestart.</b> Door deel te nemen geeft
-        u toestemming om een transcriptie te maken van deze vergadering.
+    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Opname is gestart.</b> Door deel te nemen geeft u
+        toestemming voor het transcriberen van deze vergadering.
          <u>Privacybeleid</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>Opname wordt opgeslagen.</b> Opname is gestopt.
          <u>Meer informatie</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>Transcriptie is gestart.</b> Door deel te nemen geeft
-        u toestemming om een transcriptie te maken van deze vergadering. <u>Privacybeleid</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>Transcriptie is gestart.</b> Door deel te nemen geeft u
+        toestemming voor het transcriberen van deze vergadering. <u>Privacybeleid</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>Transcriptie wordt opgeslagen.</b> Transcriptie
         is gestopt. <u>Meer informatie</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>Opname en transcriptie zijn
-        gestart.</b> Door deel te nemen geeft u toestemming om een transcriptie te maken van deze vergadering
+        gestart.</b> Door deel te nemen geeft u toestemming voor het transcriberen van deze vergadering
         . <u>Privacybeleid</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>Opname en transcriptie
-        worden opgeslagen.</b> Opname en transcriptie zijn gestopt. <u>Meer informatie</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>Opname en transcriptie worden
+        opgeslagen.</b> Opname en transcriptie zijn gestopt. <u>Meer informatie</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>Opname is gestopt.</b> U
-        maakt nu alleen een transcriptie van deze vergadering. <u>Privacybeleid</u></string>
+        bent nu alleen deze vergadering aan het transcriberen. <u>Privacybeleid</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>Transcriptie is gestopt.
-        </b>U maakt nu alleen een opname van deze vergadering. <u>Privacybeleid</u></string>
+    </b> U bent nu alleen deze vergadering aan het opnemen. <u>Privacybeleid</u></string>
     <string name="azure_communication_ui_calling_view_link">Koppeling</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Sluiten</string>
     <string name="azure_communication_ui_calling_alert_title">Waarschuwing</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">U bent uit de oproep verwijderd vanwege een fout.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">Mogelijk bent u uit de vergadering verwijderd of is de verbinding verbroken. Probeer opnieuw mee te doen.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Kan niet deelnemen aan de oproep vanwege een fout.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">U bent verwijderd uit het gesprek.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Kan niet deelnemen aan gesprek. Controleer de netwerkverbinding.</string>

--- a/azure-communication-ui/calling/src/main/res/values-pl-rPL/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-pl-rPL/azure_communication_ui_calling_strings.xml
@@ -19,10 +19,10 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_off">Mikrofon wyłączony</string>
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">Mikrofon włączony</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">Dołącz do rozmowy</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Dźwięk jest wyłączony. Aby włączyć, przejdź do ustawień, aby zezwolić na dostęp. Aby rozpocząć to połączenie, musisz
- włączyć dźwięk.</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Kamera jest wyłączona. Aby włączyć, przejdź do obszaru Ustawienia
-,        aby zezwolić na dostęp.</string>
+    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Dźwięk jest wyłączony. Aby go włączyć, przejdź do obszaru Ustawienia, aby zezwolić na dostęp. Musisz
+        włączyć dźwięk, aby rozpocząć to połączenie.</string>
+    <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Kamera jest wyłączona. Aby ją włączyć, przejdź do obszaru Ustawienia,
+        aby zezwolić na dostęp.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Wymagane są uprawnienia</string>
     <string name="azure_communication_ui_calling_setup_view_go_to_settings">Przejdź do ustawień</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Wybrano</string>
@@ -65,30 +65,30 @@
     <string name="azure_communication_ui_calling_view_share_diagnostics_title">Informacje diagnostyczne</string>
 
     <!--    Compliance Banner-->
-    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Rozpoczęto nagrywanie.</b> Dołączając, 
- wyrażasz zgodę na transkrybowanie tego spotkania.
- <u> Zasady ochrony prywatności</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>Trwa zapisywanie nagrywania.</b> Nagrywanie zostało zatrzymane.
+    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Rozpoczęto nagrywanie.</b> Dołączając,
+        wyrażasz zgodę na transkrypcję tego spotkania.
+         <u>Zasady ochrony prywatności</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>Trwa zapisywanie nagrania.</b> Nagrywanie zostało zatrzymane.
          <u>Dowiedz się więcej</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>Transkrypcja została uruchomiona.</b>Dołączając,
-        wyrażasz zgodę na transkrypcję tego spotkania. <u> Zasady prywatności</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>Trwa zapisywanie transkrypcji.</b> Zatrzymano
-        transkrypcję. <u>Dowiedz się więcej</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>Rozpoczęto nagrywanie i transkrypcję
-.</b> Dołączając, wyrażasz zgodę na transkrypcję tego spotkania
-        . <u> Zasady ochrony prywatności</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>Rejestrowanie i transkrypcja są
- zapisywane.</b> Nagrywanie i transkrypcja zostały zatrzymane. <u>Dowiedz się więcej</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>Rozpoczęto transkrypcję.</b>Dołączając,
+        wyrażasz zgodę na transkrypcję tego spotkania. <u>Zasady ochrony prywatności</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>Trwa zapisywanie transkrypcji.</b> Transkrypcja
+        została zatrzymana. <u>Dowiedz się więcej</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>Rozpoczęto nagrywanie i transkrypcję.
+        </b> Dołączając, wyrażasz zgodę na transkrypcję tego spotkania.
+          <u>Zasady ochrony prywatności</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>Nagranie i transkrypcja są
+        zapisywane.</b> Nagrywanie i transkrypcja zostały zatrzymane. <u>Dowiedz się więcej</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>Nagrywanie zostało zatrzymane.</b>
-        Teraz tylko transkrybują to spotkanie. <u>Zasad ochrony prywatności</u></string>
+        Teraz tylko transkrybujesz to spotkanie. <u>Zasady ochrony prywatności</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>Transkrypcja została zatrzymana.
-    </b> Nagrywasz teraz tylko to spotkanie. <u>Zasady ochrony prywatności</u></string>
+    </b> Teraz tylko nagrywasz to spotkanie. <u>Zasady ochrony prywatności</u></string>
     <string name="azure_communication_ui_calling_view_link">Link</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Odrzuć</string>
     <string name="azure_communication_ui_calling_alert_title">Alert</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">Usunięto Cię z rozmowy z powodu błędu.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">Być może usunięto Cię ze spotkania lub utracono połączenie. Spróbuj ponownie dołączyć.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Nie można dołączyć do połączenia z powodu błędu.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">Usunięto Cię z rozmowy.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Nie można dołączyć do rozmowy. Sprawdź połączenie sieciowe.</string>

--- a/azure-communication-ui/calling/src/main/res/values-pt-rBR/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-pt-rBR/azure_communication_ui_calling_strings.xml
@@ -20,9 +20,9 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">Microfone ligado</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">Ingressar na chamada</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Seu áudio está desabilitado. Para habilitar, vá para Configurações para permitir o acesso. Você deve
- habilitar o áudio para iniciar essa chamada.</string>
+        habilitar o áudio para iniciar essa chamada.</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Sua câmera está desabilitada. Para habilitar, vá para Configurações
- para permitir o acesso.</string>
+        para permitir o acesso.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Permissões necessárias</string>
     <string name="azure_communication_ui_calling_setup_view_go_to_settings">Vá para Configurações</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Selecionado</string>
@@ -65,30 +65,30 @@
     <string name="azure_communication_ui_calling_view_share_diagnostics_title">Informações de diagnóstico</string>
 
     <!--    Compliance Banner-->
-    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>A transcrição foi iniciada.</b> Ingressando, você está
-dando consentimento para que esta reunião seja transcrita.
- <u>Política de privacidade</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>A gravação foi iniciada.</b> Ao ingressar, você está
+        dando consentimento para que esta reunião seja transcrita.
+         <u>Política de privacidade</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>A gravação está sendo salva.</b> A gravação foi interrompida.
          <u>Saiba mais</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>A transcrição foi iniciada.</b> Ingressando, você
+    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>A transcrição foi iniciada.</b> Ao ingressar, você
         está dando consentimento para que esta reunião seja transcrita. <u>Política de privacidade</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>A transcrição está sendo salva.</b> A transcrição
         foi interrompida. <u>Saiba mais</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>A gravação e a transcrição foram
- iniciadas.</b> Ingressando, você está dando consentimento para que esta reunião seja transcrita
-    . <u>Política de privacidade</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>A gravação e a transcrição
+        iniciaram.</b> Ao ingressar, você está dando consentimento para que esta reunião seja transcrita
+        . <u>Política de privacidade</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>A gravação e a transcrição estão
-        sendo salvas.</b> A gravação e a transcrição foram interrompidas. <u>Saiba mais</u></string>
+        sendo salvas.</b> A gravação e transcrição foram interrompidas. <u>Saiba mais</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>A gravação foi interrompida.</b> Você
         agora só está transcrevendo esta reunião. <u>Política de privacidade</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>A transcrição foi interrompida.
-    </b> Você agora só está gravando esta reunião. <u>Política de privacidade</u></string>
+    </b> Agora você está gravando apenas esta reunião. <u>Política de privacidade</u></string>
     <string name="azure_communication_ui_calling_view_link">Link</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Ignorar</string>
     <string name="azure_communication_ui_calling_alert_title">Alerta</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">Você foi removido da chamada devido a um erro.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">Você pode ter sido removido da reunião ou perdido a conexão. Tente entrar novamente.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Não é possível ingressar na chamada devido a um erro.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">Você foi removido da chamada.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Não é possível ingressar na chamada. Verifique sua conexão de rede.</string>

--- a/azure-communication-ui/calling/src/main/res/values-ru-rRU/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-ru-rRU/azure_communication_ui_calling_strings.xml
@@ -19,8 +19,8 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_off">Микрофон выключен</string>
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">Микрофон включен</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">Присоединиться к звонку</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Звук отключен. Для включения перейдите в раздел "Параметры", чтобы разрешить доступ. Чтобы начать
-        этот звонок, включите звук.</string>
+    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Звук отключен. Для включения перейдите в раздел "Параметры", чтобы разрешить доступ. Необходимо
+        включить звук, чтобы начать этот звонок.</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Камера отключена. Для включения перейдите в раздел "Параметры",
         чтобы разрешить доступ.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">Требуются разрешения</string>
@@ -82,13 +82,13 @@
     <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>Запись остановлена.</b> Теперь вы
         только транскрибируете это собрание. <u>Политика конфиденциальности</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>Транскрибирование остановлено.
-    </b> Теперь вы только записываете это собрание. <u>Политика конфиденциальности</u></string>
+    </b> Сейчас вы только записываете это собрание. <u>Политика конфиденциальности</u></string>
     <string name="azure_communication_ui_calling_view_link">Ссылка</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Закрыть</string>
     <string name="azure_communication_ui_calling_alert_title">Оповещение</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">Вы были удалены из звонка из-за ошибки.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">Возможно, вы были удалены из собрания или потеряли подключение. Попробуйте присоединиться еще раз.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Не удалось присоединиться к звонку из-за ошибки.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">Вас удалили из вызова.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Не удалось присоединиться к звонку. Проверьте сетевое подключение.</string>

--- a/azure-communication-ui/calling/src/main/res/values-sv-rSE/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-sv-rSE/azure_communication_ui_calling_strings.xml
@@ -65,22 +65,22 @@
     <string name="azure_communication_ui_calling_view_share_diagnostics_title">Diagnostikinformation</string>
 
     <!--    Compliance Banner-->
-    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Inspelning har startat.</b> Genom att ansluta
-        ger du medgivande för att det här mötet transkriberas.
+    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Postning har startat.</b> Genom att ansluta är du
+        ge medgivande för att det här mötet ska transkriberas.
          <u>Sekretesspolicy</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>Inspelningen sparas.</b> Inspelningen har stoppats.
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>Postning sparas.</b> Inspelningen har stoppats.
          <u>Läs mer</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>Transcription har startat.</b> Genom att gå med ger du
-        medgivande för att det här mötet transkriberas. <u>Sekretesspolicy</u></string>
+        samtycker till att det här mötet transkriberas. <u>Sekretesspolicy</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>Transkription sparas.</b> Transkription
         har stoppats. <u>Läs mer</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>Inspelning och transkription har
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>Inspelning och transkription har 
         startat.</b> Genom att ansluta ger du ditt medgivande till att det här mötet transkriberas
         . <u>Sekretesspolicy</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>Inspelning och transkription 
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>Inspelning och transkription
         sparas.</b> Inspelning och transkription har stoppats. <u>Läs mer</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>Inspelning har stoppats.</b> Du
-        transkriberar nu bara mötet. <u>Privacy-princip</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>Postningen har stoppats.</b> Du
+        transkriberar nu bara det här mötet. <u>Sekretesspolicy</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>Transkription har stoppats.
     </b> Du spelar nu bara in det här mötet. <u>Sekretesspolicy</u></string>
     <string name="azure_communication_ui_calling_view_link">Länk</string>
@@ -88,7 +88,7 @@
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Stäng</string>
     <string name="azure_communication_ui_calling_alert_title">Avisering</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">Du togs bort från samtalet på grund av ett fel.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">Du kan ha tagits bort från mötet eller förlorat anslutningen. Försök att ansluta igen.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Det gick inte att ansluta till samtalet på grund av ett fel.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">Du togs bort från samtalet.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Det går inte att ansluta till samtalet. Kontrollera nätverksanslutningen.</string>

--- a/azure-communication-ui/calling/src/main/res/values-tr-rTR/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-tr-rTR/azure_communication_ui_calling_strings.xml
@@ -19,10 +19,10 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_off">Mikrofon kapalı</string>
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">Mikrofon açık</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">Aramaya katıl</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Sesiniz devre dışı. Etkinleştirmek için Ayarlar seçeneğine giderek erişime izin verin.
-    Bu aramayı başlatmak için sesi etkinleştirmeniz gerekiyor.</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Kameranız devre dışı. Etkinleştirmek için Ayarlar seçeneğine giderek
-      erişime izin verin.</string>
+    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">Sesiniz devre dışı bırakıldı. Etkinleştirmek için, erişime izin vermek üzere lütfen Ayarlar bölümüne gidin. Bu
+        aramayı başlatmak için sesi etkinleştirmeniz gerekiyor.</string>
+    <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">Kameranız devre dışı. Etkinleştirmek için Ayarlar bölümüne giderek
+        erişime izin verin.</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">İzinler gerekli</string>
     <string name="azure_communication_ui_calling_setup_view_go_to_settings">Ayarlara Git</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">Seçili</string>
@@ -66,29 +66,29 @@
 
     <!--    Compliance Banner-->
     <string name="azure_communication_ui_calling_view_banner_recording_started"><b>Kayıt başlatıldı.</b> Katılarak,
-    bu toplantının dökümünün alınmasına izin veriyorsunuz.
-       <u>Gizlilik ilkesi</u></string>
+        bu toplantının dökümünün çıkarılmasına onay verirsiniz.
+         <u>Gizlilik ilkesi</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>Kayıt kaydediliyor.</b> Kayıt durduruldu.
-         <u>Daha fazla bilgi edinin</u></string>
+         <u>Daha Fazla Bilgi Edinin</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>Döküm başlatıldı.</b> Katılarak,
-    bu toplantının dökümünün alınmasına izin veriyorsunuz. <u>Gizlilik ilkesi</u></string>
+        bu toplantının dökümünün çıkarılmasına onay verirsiniz. <u>Gizlilik ilkesi</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>Döküm kaydediliyor.</b> Döküm
-        durduruldu. <u>Daha fazla bilgi edinin</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>Kayıt ve döküm başlatıldı.</b> Katılarak,
-    bu toplantının dökümünün alınmasına izin veriyorsunuz
-      . <u>Gizlilik ilkesi</u></string>
+        durduruldu. <u>Daha Fazla Bilgi Edinin</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>Kayıt ve döküm
+        başlatıldı.</b> Katılarak bu toplantının dökümünün alınmasına izin verirsiniz
+        . <u>Gizlilik ilkesi</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>Kayıt ve döküm
-        kaydediliyor.</b> Kayıt ve döküm durduruldu. <u>Daha fazla bilgi edinin</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>Kayıt durduruldu.</b>
-    Şu anda yalnızca bu toplantının dökümünü alıyorsunuz. <u>Gizlilik ilkesi</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>Döküm durduruldu.</b>
-    Şu anda yalnızca bu toplantıyı kaydediyorsunuz. <u>Gizlilik ilkesi</u></string>
+        kaydediliyor.</b> Kayıt ve döküm durduruldu. <u>Daha Fazla Bilgi Edinin</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>Kayıt durduruldu.</b> Şu anda
+        bu toplantının yalnızca dökümünü oluşturuyorsunuz. <u>Gizlilik ilkesi</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>Döküm durduruldu.
+    </b> Şu anda yalnızca bu toplantıyı kaydediyorsunuz. <u>Gizlilik ilkesi</u></string>
     <string name="azure_communication_ui_calling_view_link">Bağlantı</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Kapat</string>
     <string name="azure_communication_ui_calling_alert_title">Uyarı</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">Bir hata nedeniyle aramadan çıkarıldınız.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">Toplantıdan çıkarılmış olabilirsiniz veya bağlantınız kesilmiş olabilir. Yeniden katılmayı deneyin.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Bir hata nedeniyle aramaya katılınamıyor.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">Aramadan çıkarıldınız.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Aramaya katılınamıyor. Ağ bağlantınızı kontrol edin.</string>

--- a/azure-communication-ui/calling/src/main/res/values-zh-rCN/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-zh-rCN/azure_communication_ui_calling_strings.xml
@@ -19,10 +19,10 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_off">关闭麦克风</string>
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">打开麦克风</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">加入通话</string>
-    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">你的音频已禁用。若要启用，请转到“设置”以允许访问。
-必须启用音频才能开始此通话。</string>
+    <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">你的音频已禁用。若要启用，请转到“设置”以允许访问。必须
+       启用音频以开始此通话。</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">你的相机已禁用。若要启用，请转到“设置”
-以允许访问。</string>
+       以允许访问。</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">需要权限</string>
     <string name="azure_communication_ui_calling_setup_view_go_to_settings">转到“设置”</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">已选择</string>
@@ -65,30 +65,30 @@
     <string name="azure_communication_ui_calling_view_share_diagnostics_title">诊断信息</string>
 
     <!--    Compliance Banner-->
-    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>录制已开始。</b>加入即表示你
-同意誊写此会议。
- <u>隐私策略</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>录制已启动。</b>加入即表示
+       你同意听录此会议。
+        <u>隐私策略</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>正在保存录制。</b>录制已停止。
-<u>了解详细信息</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>听录已开始。</b>加入即表示你
-同意誊写此会议。<u>隐私策略</u></string>
+        <u>了解详细信息</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>听录已开始。</b>加入即表示
+       你同意听录此会议。<u>隐私策略</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>正在保存听录。</b>听录
-已停止。<u>了解详细信息</u></string>
+       已停止。<u>了解详细信息</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>录制和听录已
-已启动。</b>加入即表示你同意誊写此会议
-。<u>隐私策略</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>正在
-保存录制和听录。</b>录制和听录已停止。<u>了解详细信息</u></string>
+       开始。</b>加入即表示你同意听录此会议。
+       。<u>隐私策略</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>录制和听录
+       正在保存。</b> 录制和听录已停止。<u>了解详细信息</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>录制已停止。</b>你
-现在仅在誊写此会议。<u>隐私策略</u></string>
+       现在仅听录此会议。<u>隐私策略</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>听录已停止。
-</b>你现在仅在录制此会议。<u>隐私策略</u></string>
+   </b>现在仅录制此会议。<u>隐私策略</u></string>
     <string name="azure_communication_ui_calling_view_link">链接</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">关闭</string>
     <string name="azure_communication_ui_calling_alert_title">警报</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">由于出现错误，你已从通话中删除。</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">系统可能已将你从会议中删除，或者你的连接已中断。请再次尝试加入。</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">由于出现错误，无法加入呼叫。</string>
     <string name="azure_communication_ui_calling_call_state_evicted">已将你从通话中移除。</string>
     <string name="azure_communication_ui_calling_no_connection_available">无法加入呼叫。请检查网络连接。</string>

--- a/azure-communication-ui/calling/src/main/res/values-zh-rTW/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values-zh-rTW/azure_communication_ui_calling_strings.xml
@@ -20,9 +20,9 @@
     <string name="azure_communication_ui_calling_setup_view_button_mic_on">麥克風開啟</string>
     <string name="azure_communication_ui_calling_setup_view_button_join_call">加入通話</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_audio_disabled">您的音訊已停用。若要啟用，請移至 [設定] 以允許存取。您必須
-        啟用音訊才能開始此通話。</string>
+       啟用音訊才能開始此通話。</string>
     <string name="azure_communication_ui_calling_setup_view_preview_area_camera_disabled">您的相機已停用。若要啟用，請移至 [設定]
-        以允許存取。</string>
+       以允許存取。</string>
     <string name="azure_communication_ui_calling_setup_view_warning_missing_text">需要權限</string>
     <string name="azure_communication_ui_calling_setup_view_go_to_settings">移至 [設定]</string>
     <string name="azure_communication_ui_calling_setup_view_audio_device_selected_accessibility_label">已選取</string>
@@ -65,30 +65,30 @@
     <string name="azure_communication_ui_calling_view_share_diagnostics_title">診斷資訊</string>
 
     <!--    Compliance Banner-->
-    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>錄製已開始。</b>一旦加入，即表示您
-        同意轉譯此會議。
-         <u>隱私權原則</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_started"><b>[錄製] 已啟動。</b>加入後，即表示您
+       同意轉譯此會議。
+        <u>隱私權原則</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_stopped"><b>錄製已儲存。</b>錄製已停止。
-         <u>深入了解</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>轉錄已開始。</b>一旦加入，即表示您
-        同意轉譯此會議。<u>隱私權原則</u></string>
+        <u>深入了解</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_started"><b>[謄寫] 已啟動。</b>加入後，即表示您
+       同意轉譯此會議。<u>隱私權原則</u></string>
     <string name="azure_communication_ui_calling_view_banner_transcription_stopped"><b>轉錄已儲存。</b>轉錄
-        已停止。<u>深入了解</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>錄製和轉錄
-        已開始。</b>一旦加入，即表示您同意轉譯此會議
-        。<u>隱私權原則</u></string>
+       已停止。<u>深入了解</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_started"><b>錄製和轉錄已
+       開始。</b>一旦加入，即表示您同意轉譯此會議
+       。<u>隱私權原則</u></string>
     <string name="azure_communication_ui_calling_view_banner_recording_and_transcribing_stopped"><b>錄製和轉錄
-        已儲存。</b>錄製和轉錄已停止。<u>深入了解</u></string>
-    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>錄製已停止。</b> 您
-        現在只能轉譯此會議。<u>隱私權原則</u></string>
-    <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>轉錄已停止。</b> 您
-        現在只能錄製此會議。<u>隱私權原則</u></string>
+       正在儲存。</b>已停止錄製與謄寫。<u>深入了解</u></string>
+    <string name="azure_communication_ui_calling_view_banner_recording_stopped_still_transcribing"><b>您的錄製已停止。</b>您
+       現在只謄寫此會議。<u>隱私權原則</u></string>
+    <string name="azure_communication_ui_calling_view_banner_transcription_stopped_still_recording"><b>已停止轉錄。
+   </b>您現在只會錄製此會議。<u>隱私權原則</u></string>
     <string name="azure_communication_ui_calling_view_link">連結</string>
 
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">關閉</string>
     <string name="azure_communication_ui_calling_alert_title">警示</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">因為發生錯誤，您已從通話中移除。</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">您可能已從會議中移除，或中斷您的連線。再次嘗試加入。</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">發生錯誤，因此無法加入通話。</string>
     <string name="azure_communication_ui_calling_call_state_evicted">已從通話中移除您。</string>
     <string name="azure_communication_ui_calling_no_connection_available">無法加入通話。檢查您的網路連線。</string>

--- a/azure-communication-ui/calling/src/main/res/values/azure_communication_ui_calling_strings.xml
+++ b/azure-communication-ui/calling/src/main/res/values/azure_communication_ui_calling_strings.xml
@@ -94,7 +94,7 @@
     <!--    PopUp warning-->
     <string name="azure_communication_ui_calling_snack_bar_button_dismiss">Dismiss</string>
     <string name="azure_communication_ui_calling_alert_title">Alert</string>
-    <string name="azure_communication_ui_calling_call_state_error_call_end">You were removed from the call due to an error.</string>
+    <string name="azure_communication_ui_calling_call_state_error_call_end">You may have been removed from the meeting, or lost your connection. Try to join again.</string>
     <string name="azure_communication_ui_calling_snack_bar_text_error_call_join">Unable to join the call due to an error.</string>
     <string name="azure_communication_ui_calling_call_state_evicted">You were removed from the call.</string>
     <string name="azure_communication_ui_calling_no_connection_available">Unable to join call. Check your network connection.</string>

--- a/eng/pipelines/Localization.yml
+++ b/eng/pipelines/Localization.yml
@@ -70,7 +70,7 @@ extends:
                 condition: ne(variables['commit'], 'true')
                 inputs:
                   teamId: "44987"
-                  authId: $(AUTHID_)
+                  authId: $(authId)
                   authKey: $(AUTH_KEY)
                   relativePathRoot: azure-communication-ui/azure-communication-ui/src/main/res/values
                   resourceFilePath: azure_communication_ui_strings.xml;P:246
@@ -81,7 +81,7 @@ extends:
                 condition: eq(variables['commit'], 'true')
                 inputs:
                   teamId: "44987"
-                  authId: $(AUTHID_)
+                  authId: $(authId)
                   authKey: $(AUTH_KEY)
                   relativePathRoot: azure-communication-ui/calling/src/main/res/values
                   resourceFilePath: azure_communication_ui_calling_strings.xml;P:246


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix for bug: [Bug 3494181](https://skype.visualstudio.com/SPOOL/_workitems/edit/3494181): [Call UI - TDL] [Android] User doesn't get appropriate displayed error message in "Setup" menu if User has lost internet connection

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [x] Yes
- [] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [x] UI Changes
  - [x] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* 
![Screenshot_20240131-171549](https://github.com/Azure/communication-ui-library-android/assets/99507832/e89ab903-d9f5-4c2e-8c62-880cc32fc61e)
![Screenshot_20240131-172852](https://github.com/Azure/communication-ui-library-android/assets/99507832/9ab8708d-6e9a-4a09-ac49-ccaf5feebc9f)


## Other Information
<!-- Add any other helpful information that may be needed here. -->
