### PR TITLE
Fix packaging of R and BuildConfig to move into .ui.calling.impl

### DIFF
--- a/azure-communication-ui/build.gradle
+++ b/azure-communication-ui/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        call_library_version_name = '1.5.0'
+        call_library_version_name = '1.6.0'
         chat_library_version_name = '1.0.0-beta.3'
 
         ui_library_version_code = getVersionCode()

--- a/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/BaseUiTest.kt
+++ b/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/BaseUiTest.kt
@@ -8,7 +8,7 @@ import com.azure.android.communication.mocking.CallEvents
 import com.azure.android.communication.mocking.TestCallingSDK
 import com.azure.android.communication.mocking.TestContextProvider
 import com.azure.android.communication.mocking.TestVideoStreamRendererFactory
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.utilities.TestHelper
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher

--- a/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/ui/calling/LobbyTest.kt
+++ b/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/ui/calling/LobbyTest.kt
@@ -24,7 +24,7 @@ import com.azure.android.communication.waitUntilDisplayed
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.util.UUID
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.models.CallCompositeLobbyErrorCode
 import java9.util.concurrent.CompletableFuture
 

--- a/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/ui/calling/ToastNotificationTest.kt
+++ b/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/ui/calling/ToastNotificationTest.kt
@@ -7,7 +7,7 @@ import com.azure.android.communication.BaseUiTest
 import com.azure.android.communication.assertDisplayed
 import com.azure.android.communication.assertViewGone
 import com.azure.android.communication.assertViewText
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.tapWhenDisplayed
 import com.azure.android.communication.waitUntilDisplayed
 import kotlinx.coroutines.test.runTest

--- a/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/ui/calling/UpperBarMessageNotificationTest.kt
+++ b/azure-communication-ui/calling/src/androidTest/java/com/azure/android/communication/ui/calling/UpperBarMessageNotificationTest.kt
@@ -8,7 +8,7 @@ import com.azure.android.communication.assertDisplayed
 import com.azure.android.communication.assertNotDisplayed
 import com.azure.android.communication.assertViewText
 import com.azure.android.communication.tap
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.tapWhenDisplayed
 import com.azure.android.communication.waitUntilDisplayed
 import kotlinx.coroutines.test.runTest

--- a/azure-communication-ui/calling/src/main/AndroidManifest.xml
+++ b/azure-communication-ui/calling/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
    Licensed under the MIT License.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.azure.android.communication.ui"
+    package="com.azure.android.communication.ui.calling.impl"
     >
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -23,7 +23,7 @@
     <application android:hardwareAccelerated="true">
 
         <activity
-            android:name=".calling.presentation.MultitaskingCallCompositeActivity"
+            android:name="com.azure.android.communication.ui.calling.presentation.MultitaskingCallCompositeActivity"
             android:exported="false"
             android:launchMode="singleTask"
             android:excludeFromRecents="true"
@@ -32,7 +32,7 @@
             />
 
         <activity
-            android:name=".calling.presentation.PiPCallCompositeActivity"
+            android:name="com.azure.android.communication.ui.calling.presentation.PiPCallCompositeActivity"
             android:exported="false"
             android:launchMode="singleTask"
             android:supportsPictureInPicture="true"

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/DiagnosticConfig.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/DiagnosticConfig.kt
@@ -3,7 +3,7 @@
 
 package com.azure.android.communication.ui.calling
 
-import com.azure.android.communication.ui.BuildConfig
+import com.azure.android.communication.ui.calling.impl.BuildConfig
 
 internal class DiagnosticConfig {
     val tags: Array<String> by lazy { arrayOf(getApplicationId()) }

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeDebugInfo.java
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeDebugInfo.java
@@ -5,7 +5,7 @@ package com.azure.android.communication.ui.calling.models;
 
 import android.util.Log;
 
-import com.azure.android.communication.ui.BuildConfig;
+import com.azure.android.communication.ui.calling.impl.BuildConfig;
 
 import java.io.File;
 import java.util.Collections;

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/CallCompositeActivity.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/CallCompositeActivity.kt
@@ -24,7 +24,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentTransaction
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.CallCompositeInstanceManager
 import com.azure.android.communication.ui.calling.models.CallCompositeSupportedLocale
 import com.azure.android.communication.ui.calling.models.CallCompositeSupportedScreenOrientation

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/DependencyInjectionContainerHolder.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/DependencyInjectionContainerHolder.kt
@@ -5,7 +5,7 @@ package com.azure.android.communication.ui.calling.presentation
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.CallCompositeException
 import com.azure.android.communication.ui.calling.CallCompositeInstanceManager
 import com.azure.android.communication.ui.calling.di.DependencyInjectionContainer

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingFragment.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingFragment.kt
@@ -18,7 +18,7 @@ import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.CallCompositeInstanceManager
 import com.azure.android.communication.ui.calling.presentation.DependencyInjectionContainerHolder
 import com.azure.android.communication.ui.calling.presentation.MultitaskingCallCompositeActivity

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/banner/BannerView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/banner/BannerView.kt
@@ -15,7 +15,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/ControlBarView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/ControlBarView.kt
@@ -15,7 +15,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.redux.state.AudioDeviceSelectionStatus
 import com.azure.android.communication.ui.calling.redux.state.AudioOperationalStatus
 import com.azure.android.communication.ui.calling.redux.state.CallingStatus

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/more/MoreCallOptionsListView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/more/MoreCallOptionsListView.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.utilities.BottomCellAdapter
 import com.azure.android.communication.ui.calling.utilities.BottomCellItem
 import com.microsoft.fluentui.drawer.DrawerDialog

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/more/MoreCallOptionsListViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/more/MoreCallOptionsListViewModel.kt
@@ -3,7 +3,7 @@
 
 package com.azure.android.communication.ui.calling.presentation.fragment.calling.controlbar.more
 
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.presentation.manager.DebugInfoManager
 import com.azure.android.communication.ui.calling.redux.Dispatch
 import com.azure.android.communication.ui.calling.redux.action.NavigationAction

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hangup/LeaveConfirmView.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.utilities.BottomCellAdapter
 import com.azure.android.communication.ui.calling.utilities.BottomCellItem
 import com.azure.android.communication.ui.calling.utilities.BottomCellItemType

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/header/InfoHeaderView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/header/InfoHeaderView.kt
@@ -12,7 +12,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.presentation.MultitaskingCallCompositeActivity
 import com.azure.android.communication.ui.calling.utilities.isAndroidTV
 import com.microsoft.fluentui.util.activity

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hold/OnHoldOverlayView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/hold/OnHoldOverlayView.kt
@@ -22,7 +22,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.utilities.isAndroidTV
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.microsoft.fluentui.snackbar.Snackbar

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/lobby/ConnectingLobbyOverlayView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/lobby/ConnectingLobbyOverlayView.kt
@@ -15,7 +15,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/lobby/LobbyErrorHeaderView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/lobby/LobbyErrorHeaderView.kt
@@ -12,7 +12,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.models.CallCompositeLobbyErrorCode
 import com.azure.android.communication.ui.calling.utilities.isAndroidTV
 import kotlinx.coroutines.flow.collect

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/lobby/LobbyHeaderView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/lobby/LobbyHeaderView.kt
@@ -11,7 +11,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.utilities.isAndroidTV
 import com.microsoft.fluentui.widget.Button
 import kotlinx.coroutines.flow.collect

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/lobby/WaitingLobbyOverlayView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/lobby/WaitingLobbyOverlayView.kt
@@ -14,7 +14,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantView.kt
@@ -16,7 +16,7 @@ import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.azure.android.communication.calling.ScalingMode
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.presentation.VideoViewManager
 import com.azure.android.communication.ui.calling.presentation.manager.AvatarViewManager
 import com.azure.android.communication.ui.calling.redux.state.CameraDeviceSelectionStatus

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/ToastNotificationView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/ToastNotificationView.kt
@@ -14,7 +14,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/ToastNotificationViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/ToastNotificationViewModel.kt
@@ -3,7 +3,7 @@
 
 package com.azure.android.communication.ui.calling.presentation.fragment.calling.notification
 
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.models.CallDiagnosticQuality
 import com.azure.android.communication.ui.calling.models.MediaCallDiagnostic
 import com.azure.android.communication.ui.calling.models.MediaCallDiagnosticModel

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/UpperMessageBarNotificationLayoutView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/UpperMessageBarNotificationLayoutView.kt
@@ -9,7 +9,7 @@ import android.view.View
 import android.widget.LinearLayout
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/UpperMessageBarNotificationLayoutViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/UpperMessageBarNotificationLayoutViewModel.kt
@@ -3,7 +3,7 @@
 
 package com.azure.android.communication.ui.calling.presentation.fragment.calling.notification
 
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.models.MediaCallDiagnostic
 import com.azure.android.communication.ui.calling.models.UpperMessageBarNotificationModel
 import com.azure.android.communication.ui.calling.redux.action.Action

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/UpperMessageBarNotificationView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/notification/UpperMessageBarNotificationView.kt
@@ -14,7 +14,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/ParticipantGridCellView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/ParticipantGridCellView.kt
@@ -12,7 +12,7 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.lifecycle.LifecycleCoroutineScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.models.CallCompositeParticipantViewData
 import com.azure.android.communication.ui.calling.presentation.fragment.calling.participant.grid.cell.ParticipantGridCellAvatarView
 import com.azure.android.communication.ui.calling.presentation.fragment.calling.participant.grid.cell.ParticipantGridCellVideoView

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/ParticipantGridView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/ParticipantGridView.kt
@@ -16,7 +16,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.models.CallCompositeParticipantViewData
 import com.azure.android.communication.ui.calling.presentation.VideoViewManager
 import com.azure.android.communication.ui.calling.presentation.manager.AvatarViewManager

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/cell/ParticipantGridCellAvatarView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/cell/ParticipantGridCellAvatarView.kt
@@ -13,7 +13,7 @@ import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleCoroutineScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.models.CallCompositeParticipantViewData
 import com.azure.android.communication.ui.calling.presentation.fragment.calling.participant.grid.ParticipantGridCellViewModel
 import com.microsoft.fluentui.persona.AvatarView

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/cell/ParticipantGridCellVideoView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participant/grid/cell/ParticipantGridCellVideoView.kt
@@ -15,7 +15,7 @@ import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleCoroutineScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.models.StreamType
 import com.azure.android.communication.ui.calling.models.CallCompositeParticipantViewData
 import com.azure.android.communication.ui.calling.presentation.fragment.calling.participant.grid.ParticipantGridCellViewModel

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participantlist/ParticipantListView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/participantlist/ParticipantListView.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.models.CallCompositeParticipantViewData
 import com.azure.android.communication.ui.calling.models.ParticipantStatus
 import com.azure.android.communication.ui.calling.presentation.manager.AvatarViewManager

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/support/SupportView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/support/SupportView.kt
@@ -12,7 +12,7 @@ import androidx.appcompat.widget.SwitchCompat
 import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.microsoft.fluentui.drawer.DrawerDialog
 import com.microsoft.fluentui.widget.Button
 import kotlinx.coroutines.InternalCoroutinesApi

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/common/audiodevicelist/AudioDeviceListView.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.redux.state.AudioDeviceSelectionStatus
 import com.azure.android.communication.ui.calling.redux.state.AudioState
 import com.azure.android.communication.ui.calling.utilities.BottomCellAdapter

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/SetupFragment.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/SetupFragment.kt
@@ -18,7 +18,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.presentation.DependencyInjectionContainerHolder
 import com.azure.android.communication.ui.calling.presentation.fragment.common.audiodevicelist.AudioDeviceListView
 import com.azure.android.communication.ui.calling.presentation.fragment.setup.components.ErrorInfoView

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/ErrorInfoView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/ErrorInfoView.kt
@@ -15,7 +15,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.error.CallStateError
 import com.azure.android.communication.ui.calling.error.ErrorCode
 import com.azure.android.communication.ui.calling.models.CallCompositeEventCode

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/JoinCallButtonHolderView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/JoinCallButtonHolderView.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 
 internal class JoinCallButtonHolderView : ConstraintLayout {
     constructor(context: Context) : super(context)

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/PermissionWarningView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/PermissionWarningView.kt
@@ -16,7 +16,7 @@ import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.redux.state.PermissionStatus
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/PreviewAreaView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/PreviewAreaView.kt
@@ -10,7 +10,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.azure.android.communication.calling.ScalingMode
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.presentation.VideoViewManager
 import com.azure.android.communication.ui.calling.utilities.isAndroidTV
 import kotlinx.coroutines.flow.collect

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/SetupControlBarView.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/setup/components/SetupControlBarView.kt
@@ -14,7 +14,7 @@ import androidx.appcompat.widget.AppCompatButton
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.redux.state.AudioDeviceSelectionStatus
 import com.azure.android.communication.ui.calling.redux.state.AudioOperationalStatus
 import com.azure.android.communication.ui.calling.redux.state.AudioState

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/manager/AccessibilityAnnouncementManager.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/manager/AccessibilityAnnouncementManager.kt
@@ -7,7 +7,7 @@ import android.app.Activity
 import android.content.Context
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityManager
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.redux.Store
 import com.azure.android.communication.ui.calling.redux.state.AudioOperationalStatus
 import com.azure.android.communication.ui.calling.redux.state.CallingStatus

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/manager/AudioSessionManager.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/manager/AudioSessionManager.kt
@@ -13,7 +13,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.media.AudioManager
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.redux.Store
 import com.azure.android.communication.ui.calling.redux.action.LocalParticipantAction
 import com.azure.android.communication.ui.calling.redux.state.AudioDeviceSelectionStatus

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/service/InCallService.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/service/InCallService.kt
@@ -13,7 +13,7 @@ import android.os.Binder
 import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.presentation.CallCompositeActivity
 import com.azure.android.communication.ui.calling.presentation.MultitaskingCallCompositeActivity
 import com.azure.android.communication.ui.calling.presentation.PiPCallCompositeActivity

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/utilities/BottomCellActionViewHolder.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/utilities/BottomCellActionViewHolder.kt
@@ -10,7 +10,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.AccessibilityDelegateCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.microsoft.fluentui.persona.AvatarView
 
 internal class BottomCellActionViewHolder(itemView: View) : BottomCellViewHolder(itemView) {

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/utilities/BottomCellAdapter.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/utilities/BottomCellAdapter.kt
@@ -7,7 +7,7 @@ import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 
 internal class BottomCellAdapter : RecyclerView.Adapter<BottomCellViewHolder>() {
     private var bottomCellItems: List<BottomCellItem> = mutableListOf()

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/utilities/BottomCellViewHolder.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/utilities/BottomCellViewHolder.kt
@@ -6,7 +6,7 @@ package com.azure.android.communication.ui.calling.utilities
 import android.view.View
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.microsoft.fluentui.widget.Button
 
 internal open class BottomCellViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/presentation/manager/AccessibilityAnnouncementManagerUnitTests.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/presentation/manager/AccessibilityAnnouncementManagerUnitTests.kt
@@ -5,7 +5,7 @@ package com.azure.android.communication.ui.presentation.manager
 
 import android.content.Context
 import com.azure.android.communication.ui.ACSBaseTestCoroutine
-import com.azure.android.communication.ui.R
+import com.azure.android.communication.ui.calling.impl.R
 import com.azure.android.communication.ui.calling.presentation.manager.CameraStatusHook
 import com.azure.android.communication.ui.calling.presentation.manager.MeetingJoinedHook
 import com.azure.android.communication.ui.calling.presentation.manager.MicStatusHook

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/AppStoreUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/AppStoreUnitTest.kt
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.android.communication.ui.redux
+package com.azure.android.communication.ui.calling.impl.Redux
 
 import com.azure.android.communication.ui.ACSBaseTestCoroutine
 import com.azure.android.communication.ui.calling.models.ParticipantInfoModel

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/middleware/CallingMiddlewareUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/middleware/CallingMiddlewareUnitTest.kt
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.android.communication.ui.redux.middleware
+package com.azure.android.communication.ui.calling.impl.Redux.middleware
 
 import com.azure.android.communication.ui.calling.logger.DefaultLogger
 import com.azure.android.communication.ui.calling.redux.AppStore

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandlerUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/middleware/handler/CallingMiddlewareActionHandlerUnitTest.kt
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.android.communication.ui.redux.middleware.handler
+package com.azure.android.communication.ui.calling.impl.Redux.middleware.handler
 
 import com.azure.android.communication.ui.ACSBaseTestCoroutine
 import com.azure.android.communication.ui.calling.error.CallStateError

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/AppReduxStateReducerUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/AppReduxStateReducerUnitTest.kt
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.android.communication.ui.redux.reducer
+package com.azure.android.communication.ui.calling.impl.Redux.reducer
 
 import com.azure.android.communication.ui.calling.redux.action.NavigationAction
 import com.azure.android.communication.ui.calling.redux.reducer.AppStateReducer

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/CallDiagnosticsReducerUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/CallDiagnosticsReducerUnitTest.kt
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.android.communication.ui.redux.reducer
+package com.azure.android.communication.ui.calling.impl.Redux.reducer
 
 import com.azure.android.communication.ui.calling.models.CallDiagnosticQuality
 import com.azure.android.communication.ui.calling.models.MediaCallDiagnostic

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/CallingReducerUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/CallingReducerUnitTest.kt
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.android.communication.ui.redux.reducer
+package com.azure.android.communication.ui.calling.impl.Redux.reducer
 
 import com.azure.android.communication.ui.calling.redux.reducer.CallStateReducerImpl
 import com.azure.android.communication.ui.calling.redux.action.CallingAction

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/ErrorReducerUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/ErrorReducerUnitTest.kt
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.android.communication.ui.redux.reducer
+package com.azure.android.communication.ui.calling.impl.Redux.reducer
 
 import com.azure.android.communication.ui.calling.error.ErrorCode
 import com.azure.android.communication.ui.calling.redux.reducer.ErrorReducerImpl

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/LocalParticipantReduxStateReducerUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/LocalParticipantReduxStateReducerUnitTest.kt
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.android.communication.ui.redux.reducer
+package com.azure.android.communication.ui.calling.impl.Redux.reducer
 
 import com.azure.android.communication.ui.calling.error.CallCompositeError
 import com.azure.android.communication.ui.calling.error.ErrorCode

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/NavigationReducerUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/NavigationReducerUnitTest.kt
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.android.communication.ui.redux.reducer
+package com.azure.android.communication.ui.calling.impl.Redux.reducer
 
 import com.azure.android.communication.ui.calling.redux.reducer.NavigationReducerImpl
 import com.azure.android.communication.ui.calling.redux.action.CallingAction

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/ParticipantActionUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/ParticipantActionUnitTest.kt
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.android.communication.ui.redux.reducer
+package com.azure.android.communication.ui.calling.impl.Redux.reducer
 
 import com.azure.android.communication.ui.calling.models.CallCompositeLobbyErrorCode
 import com.azure.android.communication.ui.calling.redux.action.ParticipantAction

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/ParticipantInfoModelStateReducerUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/ParticipantInfoModelStateReducerUnitTest.kt
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.android.communication.ui.redux.reducer
+package com.azure.android.communication.ui.calling.impl.Redux.reducer
 
 import com.azure.android.communication.ui.calling.models.ParticipantInfoModel
 import com.azure.android.communication.ui.calling.models.ParticipantStatus

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/PermissionReduxStateReducerImplUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/redux/reducer/PermissionReduxStateReducerImplUnitTest.kt
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package com.azure.android.communication.ui.redux.reducer
+package com.azure.android.communication.ui.calling.impl.Redux.reducer
 
 import com.azure.android.communication.ui.calling.redux.reducer.PermissionStateReducerImpl
 import com.azure.android.communication.ui.calling.redux.action.PermissionAction

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/service/calling/DiagnosticConfigUnitTests.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/service/calling/DiagnosticConfigUnitTests.kt
@@ -1,6 +1,6 @@
 package com.azure.android.communication.ui.service.calling
 
-import com.azure.android.communication.ui.BuildConfig
+import com.azure.android.communication.ui.calling.impl.BuildConfig
 import com.azure.android.communication.ui.calling.DiagnosticConfig
 import org.junit.Assert
 import org.junit.Test


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Our AndroidManifest for calling didn't have the full package. In addition, there is a request for ARB to drop generated files into .impl package if they don't need to be published.

This PR fixes the manifest and updates the imports.

Also, fixed version number for release.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
