### PR TITLE
[CALLING] Hidden Visibility of Local Participant View in respect to Audio Only Mode

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/CallComposite.java
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/CallComposite.java
@@ -15,7 +15,6 @@ import com.azure.android.communication.ui.calling.configuration.CallConfiguratio
 import com.azure.android.communication.ui.calling.configuration.CallType;
 import com.azure.android.communication.ui.calling.di.DependencyInjectionContainer;
 import com.azure.android.communication.ui.calling.di.DependencyInjectionContainerImpl;
-import com.azure.android.communication.ui.calling.models.CallCompositeAvMode;
 import com.azure.android.communication.ui.calling.models.CallCompositeCallStateCode;
 import com.azure.android.communication.ui.calling.models.CallCompositeCallStateChangedEvent;
 import com.azure.android.communication.ui.calling.models.CallCompositeDebugInfo;

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/CallComposite.java
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/CallComposite.java
@@ -456,16 +456,10 @@ public final class CallComposite {
 
         Class activityClass = CallCompositeActivity.class;
 
-        final CallCompositeLocalOptions localOptions = configuration.getCallCompositeLocalOptions();
-
-        final CallCompositeAvMode avMode = (localOptions != null)
-                ? localOptions.getAvMode()
-                : CallCompositeAvMode.NORMAL;
-
         if (configuration.getEnableMultitasking()) {
             activityClass = MultitaskingCallCompositeActivity.class;
         }
-        if (configuration.getEnableSystemPiPWhenMultitasking() && avMode != CallCompositeAvMode.AUDIO_ONLY) {
+        if (configuration.getEnableSystemPiPWhenMultitasking()) {
             activityClass = PiPCallCompositeActivity.class;
         }
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/CallComposite.java
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/CallComposite.java
@@ -15,6 +15,7 @@ import com.azure.android.communication.ui.calling.configuration.CallConfiguratio
 import com.azure.android.communication.ui.calling.configuration.CallType;
 import com.azure.android.communication.ui.calling.di.DependencyInjectionContainer;
 import com.azure.android.communication.ui.calling.di.DependencyInjectionContainerImpl;
+import com.azure.android.communication.ui.calling.models.CallCompositeAvMode;
 import com.azure.android.communication.ui.calling.models.CallCompositeCallStateCode;
 import com.azure.android.communication.ui.calling.models.CallCompositeCallStateChangedEvent;
 import com.azure.android.communication.ui.calling.models.CallCompositeDebugInfo;
@@ -207,7 +208,6 @@ public final class CallComposite {
 
     /**
      * Dismiss composite. If call is in progress, user will leave a call.
-     *
      */
     public void dismiss() {
         final DependencyInjectionContainer container = diContainer;
@@ -324,6 +324,7 @@ public final class CallComposite {
 
     /**
      * Add {@link CallCompositeEventHandler}
+     *
      * @param eventHandler
      */
     public void addOnPictureInPictureChangedEventHandler(
@@ -455,10 +456,16 @@ public final class CallComposite {
 
         Class activityClass = CallCompositeActivity.class;
 
+        final CallCompositeLocalOptions localOptions = configuration.getCallCompositeLocalOptions();
+
+        final CallCompositeAvMode avMode = (localOptions != null)
+                ? localOptions.getAvMode()
+                : CallCompositeAvMode.NORMAL;
+
         if (configuration.getEnableMultitasking()) {
             activityClass = MultitaskingCallCompositeActivity.class;
         }
-        if (configuration.getEnableSystemPiPWhenMultitasking()) {
+        if (configuration.getEnableSystemPiPWhenMultitasking() && avMode != CallCompositeAvMode.AUDIO_ONLY) {
             activityClass = PiPCallCompositeActivity.class;
         }
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeLocalOptions.java
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeLocalOptions.java
@@ -3,6 +3,8 @@
 
 package com.azure.android.communication.ui.calling.models;
 
+import androidx.annotation.NonNull;
+
 import com.azure.android.communication.ui.calling.CallComposite;
 
 /**
@@ -176,6 +178,7 @@ public final class CallCompositeLocalOptions {
      *
      * @return The boolean value to be used for audio only mode.
      */
+    @NonNull
     public CallCompositeAvMode getAvMode() {
         return avMode;
     }

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/DependencyInjectionContainerHolder.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/DependencyInjectionContainerHolder.kt
@@ -10,6 +10,7 @@ import com.azure.android.communication.ui.calling.CallCompositeException
 import com.azure.android.communication.ui.calling.CallCompositeInstanceManager
 import com.azure.android.communication.ui.calling.di.DependencyInjectionContainer
 import com.azure.android.communication.ui.calling.getDiContainer
+import com.azure.android.communication.ui.calling.models.CallCompositeAvMode
 import com.azure.android.communication.ui.calling.presentation.fragment.calling.CallingViewModel
 import com.azure.android.communication.ui.calling.presentation.fragment.factories.CallingViewModelFactory
 import com.azure.android.communication.ui.calling.presentation.fragment.factories.ParticipantGridCellViewModelFactory
@@ -72,7 +73,8 @@ internal class DependencyInjectionContainerHolder(
                 container.configuration.enableMultitasking
             ),
             container.networkManager,
-            container.configuration.enableMultitasking
+            container.configuration.enableMultitasking,
+            container.configuration.callCompositeLocalOptions?.avMode ?: CallCompositeAvMode.NORMAL
         )
     }
 }

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingViewModel.kt
@@ -3,6 +3,7 @@
 
 package com.azure.android.communication.ui.calling.presentation.fragment.calling
 
+import com.azure.android.communication.ui.calling.models.CallCompositeAvMode
 import com.azure.android.communication.ui.calling.models.CallCompositeInternalParticipantRole
 import com.azure.android.communication.ui.calling.models.ParticipantInfoModel
 import com.azure.android.communication.ui.calling.models.ParticipantStatus
@@ -22,7 +23,8 @@ internal class CallingViewModel(
     store: Store<ReduxState>,
     callingViewModelProvider: CallingViewModelFactory,
     private val networkManager: NetworkManager,
-    val multitaskingEnabled: Boolean
+    val multitaskingEnabled: Boolean,
+    val avMode: CallCompositeAvMode,
 ) :
     BaseViewModel(store) {
 
@@ -78,6 +80,7 @@ internal class CallingViewModel(
             state.localParticipantState.cameraState.device,
             state.localParticipantState.cameraState.camerasCount,
             state.pipState.status,
+            avMode
         )
 
         floatingHeaderViewModel.init(
@@ -162,6 +165,7 @@ internal class CallingViewModel(
             state.localParticipantState.cameraState.device,
             state.localParticipantState.cameraState.camerasCount,
             state.pipState.status,
+            avMode
         )
 
         audioDeviceListViewModel.update(
@@ -200,6 +204,7 @@ internal class CallingViewModel(
                 state.localParticipantState.cameraState.device,
                 state.localParticipantState.cameraState.camerasCount,
                 state.pipState.status,
+                avMode
             )
         }
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantViewModel.kt
@@ -86,7 +86,7 @@ internal class LocalParticipantViewModel(
     }
 
     private fun isVisible(displayVideo: Boolean, pipStatus: PictureInPictureStatus, displayFullScreenAvatar: Boolean, avMode: CallCompositeAvMode): Boolean {
-        if (avMode == CallCompositeAvMode.AUDIO_ONLY) {
+        if (avMode == CallCompositeAvMode.AUDIO_ONLY && !displayFullScreenAvatar) {
             return false
         }
 

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantViewModel.kt
@@ -3,6 +3,7 @@
 
 package com.azure.android.communication.ui.calling.presentation.fragment.calling.localuser
 
+import com.azure.android.communication.ui.calling.models.CallCompositeAvMode
 import com.azure.android.communication.ui.calling.redux.action.Action
 import com.azure.android.communication.ui.calling.redux.action.LocalParticipantAction
 import com.azure.android.communication.ui.calling.redux.state.AudioOperationalStatus
@@ -52,7 +53,8 @@ internal class LocalParticipantViewModel(
         callingState: CallingStatus,
         cameraDeviceSelectionStatus: CameraDeviceSelectionStatus,
         camerasCount: Int,
-        pipStatus: PictureInPictureStatus
+        pipStatus: PictureInPictureStatus,
+        avMode: CallCompositeAvMode,
     ) {
         val viewMode = getLocalParticipantViewMode(numberOfRemoteParticipants)
         val displayVideo = shouldDisplayVideo(videoStreamID)
@@ -80,10 +82,14 @@ internal class LocalParticipantViewModel(
         cameraDeviceSelectionFlow.value = cameraDeviceSelectionStatus
         numberOfRemoteParticipantsFlow.value = numberOfRemoteParticipants
 
-        isVisibleFlow.value = isVisible(displayVideo, pipStatus, displayFullScreenAvatar)
+        isVisibleFlow.value = isVisible(displayVideo, pipStatus, displayFullScreenAvatar, avMode)
     }
 
-    private fun isVisible(displayVideo: Boolean, pipStatus: PictureInPictureStatus, displayFullScreenAvatar: Boolean): Boolean {
+    private fun isVisible(displayVideo: Boolean, pipStatus: PictureInPictureStatus, displayFullScreenAvatar: Boolean, avMode: CallCompositeAvMode): Boolean {
+        if (avMode == CallCompositeAvMode.AUDIO_ONLY) {
+            return false
+        }
+
         return if (pipStatus == PictureInPictureStatus.PIP_MODE_ENTERED) {
             displayVideo || displayFullScreenAvatar
         } else {
@@ -103,7 +109,8 @@ internal class LocalParticipantViewModel(
         callingState: CallingStatus,
         cameraDeviceSelectionStatus: CameraDeviceSelectionStatus,
         camerasCount: Int,
-        pipStatus: PictureInPictureStatus
+        pipStatus: PictureInPictureStatus,
+        avMode: CallCompositeAvMode,
     ) {
 
         val viewMode = getLocalParticipantViewMode(numberOfRemoteParticipants)
@@ -131,7 +138,7 @@ internal class LocalParticipantViewModel(
         cameraDeviceSelectionFlow = MutableStateFlow(cameraDeviceSelectionStatus)
         isOverlayDisplayedFlow = MutableStateFlow(isOverlayDisplayed(callingState))
         numberOfRemoteParticipantsFlow = MutableStateFlow(numberOfRemoteParticipants)
-        isVisibleFlow = MutableStateFlow(isVisible(displayVideo, pipStatus, displayFullScreenAvatar))
+        isVisibleFlow = MutableStateFlow(isVisible(displayVideo, pipStatus, displayFullScreenAvatar, avMode))
     }
 
     fun switchCamera() = dispatch(LocalParticipantAction.CameraSwitchTriggered())

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingViewModelUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingViewModelUnitTest.kt
@@ -4,6 +4,7 @@
 package com.azure.android.communication.ui.calling.presentation.fragment.calling
 
 import com.azure.android.communication.ui.calling.ACSBaseTestCoroutine
+import com.azure.android.communication.ui.calling.models.CallCompositeAvMode
 import com.azure.android.communication.ui.calling.models.CallCompositeInternalParticipantRole
 import com.azure.android.communication.ui.calling.models.ParticipantInfoModel
 import com.azure.android.communication.ui.calling.models.ParticipantStatus
@@ -86,7 +87,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
             val mockConfirmLeaveOverlayViewModel = mock<LeaveConfirmViewModel> {}
 
             val mockLocalParticipantViewModel = mock<LocalParticipantViewModel> {
-                on { update(any(), any(), any(), any(), any(), any(), any(), any()) } doAnswer { }
+                on { update(any(), any(), any(), any(), any(), any(), any(), any(), any()) } doAnswer { }
             }
 
             val mockFloatingHeaderViewModel = mock<InfoHeaderViewModel> {}
@@ -136,6 +137,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
                 mockCallingViewModelProvider,
                 mockNetworkManager,
                 false,
+                CallCompositeAvMode.NORMAL
             )
 
             val newBackgroundState = AppReduxState("", false, false)
@@ -158,7 +160,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
                 any(),
             )
             verify(mockLocalParticipantViewModel, times(1)).update(
-                any(), any(), any(), any(), any(), any(), any(), any()
+                any(), any(), any(), any(), any(), any(), any(), any(), any()
             )
 
             flowJob.cancel()
@@ -188,7 +190,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
             val mockConfirmLeaveOverlayViewModel = mock<LeaveConfirmViewModel> {}
 
             val mockLocalParticipantViewModel = mock<LocalParticipantViewModel> {
-                on { update(any(), any(), any(), any(), any(), any(), any(), any()) } doAnswer { }
+                on { update(any(), any(), any(), any(), any(), any(), any(), any(), any()) } doAnswer { }
             }
 
             val mockFloatingHeaderViewModel = mock<InfoHeaderViewModel> {}
@@ -235,6 +237,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
                 mockCallingViewModelProvider,
                 mockNetworkManager,
                 false,
+                CallCompositeAvMode.NORMAL
             )
 
             val newForegroundState = AppReduxState("", false, false,)
@@ -257,7 +260,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
                 any(),
             )
             verify(mockLocalParticipantViewModel, times(2)).update(
-                any(), any(), any(), any(), any(), any(), any(), any()
+                any(), any(), any(), any(), any(), any(), any(), any(), any()
             )
 
             flowJob.cancel()
@@ -288,7 +291,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
             val mockConfirmLeaveOverlayViewModel = mock<LeaveConfirmViewModel> {}
 
             val mockLocalParticipantViewModel = mock<LocalParticipantViewModel> {
-                on { update(any(), any(), any(), any(), any(), any(), any(), any()) } doAnswer { }
+                on { update(any(), any(), any(), any(), any(), any(), any(), any(), any()) } doAnswer { }
             }
 
             val mockFloatingHeaderViewModel = mock<InfoHeaderViewModel> {}
@@ -333,6 +336,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
                 mockCallingViewModelProvider,
                 mockNetworkManager,
                 false,
+                CallCompositeAvMode.NORMAL
             )
 
             val storeState = AppReduxState("", false, false)
@@ -364,7 +368,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
                 any(),
             )
             verify(mockLocalParticipantViewModel, times(2)).update(
-                any(), any(), any(), any(), any(), any(), any(), any()
+                any(), any(), any(), any(), any(), any(), any(), any(), any()
             )
 
             flowJob.cancel()
@@ -394,7 +398,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
             val mockConfirmLeaveOverlayViewModel = mock<LeaveConfirmViewModel> {}
 
             val mockLocalParticipantViewModel = mock<LocalParticipantViewModel> {
-                on { update(any(), any(), any(), any(), any(), any(), any(), any()) } doAnswer { }
+                on { update(any(), any(), any(), any(), any(), any(), any(), any(), any()) } doAnswer { }
             }
 
             val mockFloatingHeaderViewModel = mock<InfoHeaderViewModel> {}
@@ -439,6 +443,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
                 mockCallingViewModelProvider,
                 mockNetworkManager,
                 false,
+                CallCompositeAvMode.NORMAL
             )
 
             val newForegroundState = AppReduxState("", false, false)
@@ -464,7 +469,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
                 any(),
             )
             verify(mockLocalParticipantViewModel, times(2)).update(
-                any(), any(), any(), any(), any(), any(), any(), any()
+                any(), any(), any(), any(), any(), any(), any(), any(), any()
             )
 
             flowJob.cancel()
@@ -670,6 +675,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
                 mockCallingViewModelProvider,
                 mockNetworkManager,
                 false,
+                CallCompositeAvMode.NORMAL
             )
 
             val newState = AppReduxState("", false, false)
@@ -877,6 +883,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
             mockCallingViewModelProvider,
             mockNetworkManager,
             false,
+            CallCompositeAvMode.NORMAL
         )
 
         val newState = AppReduxState("", false, false)
@@ -986,7 +993,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
         }
         val mockConfirmLeaveOverlayViewModel = mock<LeaveConfirmViewModel> {}
         val mockLocalParticipantViewModel = mock<LocalParticipantViewModel> {
-            on { update(any(), any(), any(), any(), any(), any(), any(), any()) } doAnswer { }
+            on { update(any(), any(), any(), any(), any(), any(), any(), any(), any()) } doAnswer { }
         }
         val mockLobbyHeaderViewModel = mock<LobbyHeaderViewModel> {
             on { update(any(), any(), any()) } doAnswer { }
@@ -1027,7 +1034,8 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
             mockAppStore,
             mockCallingViewModelProvider,
             mockNetworkManager,
-            false
+            false,
+            CallCompositeAvMode.NORMAL
         )
 
         val newState = AppReduxState("", false, false)
@@ -1082,7 +1090,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
             any(),
         )
         verify(mockLocalParticipantViewModel, times(2)).update(
-            any(), any(), any(), any(), any(), any(), any(), any(),
+            any(), any(), any(), any(), any(), any(), any(), any(), any()
         )
         verify(
             mockLobbyErrorHeaderViewModel,

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantGridCellViewModelTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantGridCellViewModelTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import org.junit.Assert
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
@@ -440,7 +441,38 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
         }
 
     @Test
-    fun `visibility of LocalParticipant View Model is hidden when in Audio Only Mode`() =
+    fun `Ensure the Local Participant View is not displayed when in Audio Only mode and multiple participants are displayed`() =
+        runScopedTest {
+
+            // arrange
+            val displayName = "username"
+            val audioState = AudioOperationalStatus.ON
+            val videoStreamID = null
+
+            // arrange
+            val mockAppStore = mock<AppStore<ReduxState>> {}
+            val viewModel =
+                LocalParticipantViewModel(
+                    mockAppStore::dispatch,
+                )
+
+            viewModel.init(
+                displayName = displayName,
+                audioState,
+                videoStreamID = videoStreamID,
+                numberOfRemoteParticipants = 3,
+                CallingStatus.CONNECTED,
+                CameraDeviceSelectionStatus.FRONT,
+                2,
+                PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.AUDIO_ONLY
+            )
+
+            assertFalse(viewModel.getIsVisibleFlow().value)
+        }
+
+    @Test
+    fun `Ensure the Local Participant View IS displayed when in Audio Only mode and they are alone`() =
         runScopedTest {
 
             // arrange
@@ -467,7 +499,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CallCompositeAvMode.AUDIO_ONLY
             )
 
-            assertFalse(viewModel.getIsVisibleFlow().value)
+            assertTrue(viewModel.getIsVisibleFlow().value)
         }
 
     @Test

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantGridCellViewModelTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/localuser/LocalParticipantGridCellViewModelTest.kt
@@ -9,10 +9,12 @@ import com.azure.android.communication.ui.calling.redux.state.CallingStatus
 import com.azure.android.communication.ui.calling.redux.state.CameraDeviceSelectionStatus
 import com.azure.android.communication.ui.calling.redux.state.ReduxState
 import com.azure.android.communication.ui.calling.ACSBaseTestCoroutine
+import com.azure.android.communication.ui.calling.models.CallCompositeAvMode
 import com.azure.android.communication.ui.calling.redux.state.PictureInPictureStatus
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import org.junit.Assert
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
@@ -41,6 +43,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             val isMutedFlow = mutableListOf<Boolean>()
@@ -58,6 +61,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             viewModel.update(
@@ -69,6 +73,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             viewModel.update(
@@ -80,6 +85,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             viewModel.update(
@@ -91,6 +97,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             // assert
@@ -122,6 +129,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             val displayNameFlow = mutableListOf<String?>()
@@ -139,6 +147,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             // assert
@@ -168,6 +177,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             val modelFlow = mutableListOf<LocalParticipantViewModel.VideoModel>()
@@ -185,6 +195,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             viewModel.update(
@@ -196,6 +207,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             viewModel.update(
@@ -207,6 +219,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             // assert
@@ -251,6 +264,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             val modelFlow = mutableListOf<Boolean>()
@@ -268,6 +282,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
             viewModel.update(
                 displayName,
@@ -278,6 +293,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
             viewModel.update(
                 displayName,
@@ -288,6 +304,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
             viewModel.update(
                 displayName,
@@ -298,6 +315,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             // assert
@@ -334,6 +352,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             val modelFlow = mutableListOf<Boolean>()
@@ -351,6 +370,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
             viewModel.update(
                 displayName,
@@ -361,6 +381,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.SWITCHING,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
             viewModel.update(
                 displayName,
@@ -371,6 +392,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
             viewModel.update(
                 displayName,
@@ -381,6 +403,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.SWITCHING,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
             viewModel.update(
                 displayName,
@@ -391,6 +414,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
             viewModel.update(
                 displayName,
@@ -401,6 +425,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             // assert
@@ -412,6 +437,37 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
             Assert.assertEquals(true, modelFlow[4])
 
             displayLobbyJob.cancel()
+        }
+
+    @Test
+    fun `visibility of LocalParticipant View Model is hidden when in Audio Only Mode`() =
+        runScopedTest {
+
+            // arrange
+            val displayName = "username"
+            val audioState = AudioOperationalStatus.ON
+            val videoStreamID = null
+
+            // arrange
+            val mockAppStore = mock<AppStore<ReduxState>> {}
+            val viewModel =
+                LocalParticipantViewModel(
+                    mockAppStore::dispatch,
+                )
+
+            viewModel.init(
+                displayName = displayName,
+                audioState,
+                videoStreamID = videoStreamID,
+                numberOfRemoteParticipants = 0,
+                CallingStatus.CONNECTED,
+                CameraDeviceSelectionStatus.FRONT,
+                2,
+                PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.AUDIO_ONLY
+            )
+
+            assertFalse(viewModel.getIsVisibleFlow().value)
         }
 
     @Test
@@ -439,17 +495,20 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 0,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             val getDisplayPipSwitchCameraButtonFlow = mutableListOf<Boolean>()
             val getDisplaySwitchCameraButtonFlow = mutableListOf<Boolean>()
 
             val displayPipSwitchCameraButtonFlow = launch {
-                viewModel.getDisplayPipSwitchCameraButtonFlow().toList(getDisplayPipSwitchCameraButtonFlow)
+                viewModel.getDisplayPipSwitchCameraButtonFlow()
+                    .toList(getDisplayPipSwitchCameraButtonFlow)
             }
 
             val displaySwitchCameraButtonFlow = launch {
-                viewModel.getDisplaySwitchCameraButtonFlow().toList(getDisplaySwitchCameraButtonFlow)
+                viewModel.getDisplaySwitchCameraButtonFlow()
+                    .toList(getDisplaySwitchCameraButtonFlow)
             }
 
             // act
@@ -462,6 +521,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
             viewModel.update(
                 displayName,
@@ -472,6 +532,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 0,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
             viewModel.update(
                 displayName,
@@ -482,6 +543,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 2,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
             viewModel.update(
                 displayName,
@@ -492,6 +554,7 @@ internal class LocalParticipantGridCellViewModelTest : ACSBaseTestCoroutine() {
                 CameraDeviceSelectionStatus.FRONT,
                 0,
                 PictureInPictureStatus.VISIBLE,
+                CallCompositeAvMode.NORMAL
             )
 
             // assert

--- a/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/CallLauncherActivity.kt
+++ b/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/CallLauncherActivity.kt
@@ -186,7 +186,7 @@ class CallLauncherActivity : AppCompatActivity() {
                             reportSummary.append("\nCall ID: ${debugInfo.callHistoryRecords}}")
                             // Add more information from the event as needed
                             // Prepare the large icon (screenshot) for the notification
-                            val largeIcon = if (screenshot.exists()) {
+                            val largeIcon = if (screenshot?.exists() == true) {
                                 BitmapFactory.decodeFile(screenshot.absolutePath)
                             } else {
                                 null // or a default image


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* When using Audio Only Mode, hide the local preview.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
