### PR TITLE
Fix crash after restart due to permission change

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/CallCompositeActivity.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/CallCompositeActivity.kt
@@ -24,6 +24,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentTransaction
 import androidx.lifecycle.lifecycleScope
+import com.azure.android.communication.ui.calling.CallCompositeException
 import com.azure.android.communication.ui.calling.implementation.R
 import com.azure.android.communication.ui.calling.CallCompositeInstanceManager
 import com.azure.android.communication.ui.calling.models.CallCompositeSupportedLocale
@@ -47,7 +48,6 @@ import com.microsoft.fluentui.util.activity
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import java.lang.IllegalArgumentException
 import java.lang.ref.WeakReference
 import java.util.Locale
 
@@ -94,7 +94,7 @@ internal open class CallCompositeActivity : AppCompatActivity() {
         try {
             diContainerHolder.instanceId = instanceId
             diContainerHolder.container.callCompositeActivityWeakReference = WeakReference(this)
-        } catch (invalidIDException: IllegalArgumentException) {
+        } catch (invalidIDException: CallCompositeException) {
             finish() // Container has vanished (probably due to process death); we cannot continue
             return
         }


### PR DESCRIPTION
The Activity is attempting to resume, but since the Process is destroyed (happens when the user turns off a permission), it can't resume the call.

The code does attempt to gracefully shut down here (really our only option), but it was catching the wrong exception type, and bubbling through leading to crash.

Expected is that you can't resume after process death, but it also shouldn't "crash", it should quiet quit back to the contoso application (and attempt to restore the parent activity on the new process)

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
