### PR TITLE
[Calling][Bugfix] Do not show Recording notification while in the Pip.

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingViewModel.kt
@@ -258,7 +258,10 @@ internal class CallingViewModel(
                 )
             )
 
-            bannerViewModel.update(state.callState)
+            bannerViewModel.update(
+                state.callState,
+                state.visibilityState,
+            )
         }
 
         confirmLeaveOverlayViewModel.update(state.visibilityState)

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingViewModelUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/CallingViewModelUnitTest.kt
@@ -358,7 +358,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
             verify(mockParticipantGridViewModel, times(1)).update(any(), any(), any(), any(), any())
             verify(mockFloatingHeaderViewModel, times(1)).update(any())
             verify(mockParticipantListViewModel, times(1)).update(any(), any(), any(), any())
-            verify(mockBannerViewModel, times(1)).update(any())
+            verify(mockBannerViewModel, times(1)).update(any(), any())
             verify(mockControlBarViewModel, times(2)).update(
                 any(),
                 any(),
@@ -459,7 +459,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
             verify(mockParticipantGridViewModel, times(0)).update(any(), any(), any(), any(), any())
             verify(mockFloatingHeaderViewModel, times(0)).update(any())
             verify(mockParticipantListViewModel, times(0)).update(any(), any(), any(), any())
-            verify(mockBannerViewModel, times(0)).update(any())
+            verify(mockBannerViewModel, times(0)).update(any(), any())
             verify(mockControlBarViewModel, times(2)).update(
                 any(),
                 any(),
@@ -1078,7 +1078,7 @@ internal class CallingViewModelUnitTest : ACSBaseTestCoroutine() {
             times(1)
         ).update(argThat { status -> status == CallingStatus.CONNECTED }, argThat { map -> map.size == lobbyParticipantCount }, argThat { value -> value == true })
 
-        verify(mockBannerViewModel, times(1)).update(any())
+        verify(mockBannerViewModel, times(1)).update(any(), any())
         verify(mockControlBarViewModel, times(2)).update(
             any(),
             any(),

--- a/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/banner/BannerViewModelUnitTest.kt
+++ b/azure-communication-ui/calling/src/test/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/banner/BannerViewModelUnitTest.kt
@@ -6,6 +6,8 @@ package com.azure.android.communication.ui.calling.presentation.fragment.calling
 import com.azure.android.communication.ui.calling.ACSBaseTestCoroutine
 import com.azure.android.communication.ui.calling.redux.state.CallingState
 import com.azure.android.communication.ui.calling.redux.state.CallingStatus
+import com.azure.android.communication.ui.calling.redux.state.VisibilityState
+import com.azure.android.communication.ui.calling.redux.state.VisibilityStatus
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -41,11 +43,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -78,11 +80,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -115,11 +117,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -153,11 +155,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -196,11 +198,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -239,11 +241,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -283,11 +285,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -327,11 +329,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -375,11 +377,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -423,11 +425,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -472,11 +474,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -521,11 +523,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -564,11 +566,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -608,11 +610,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -651,11 +653,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -695,11 +697,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -739,11 +741,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -783,11 +785,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -827,11 +829,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -871,11 +873,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -920,11 +922,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -969,11 +971,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1018,11 +1020,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1067,11 +1069,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1115,11 +1117,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1164,11 +1166,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1212,11 +1214,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1261,11 +1263,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1310,11 +1312,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1359,11 +1361,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1408,11 +1410,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1457,11 +1459,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1506,11 +1508,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1555,11 +1557,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1604,11 +1606,11 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
@@ -1653,16 +1655,174 @@ internal class BannerViewModelUnitTest : ACSBaseTestCoroutine() {
             }
 
             for (callingState in setupCallingStatus) {
-                bannerViewModel.update(callingState)
+                bannerViewModel.update(callingState, VisibilityState(VisibilityStatus.VISIBLE))
             }
 
             // act
-            bannerViewModel.update(testCallingState)
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
 
             // assert
             Assert.assertEquals(expectedBannerInfoType, resultBannerInfoTypeStateFlow.last())
 
             flowJob.cancel()
+        }
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun bannerBarViewModel_update_when_recordingStateOFFTranscriptionStateOFFAndIsRecordingFalseIsTranscribingFalse_then_emitCorrectBannerInfoType_VISIBLE() {
+        val testCallingState = CallingState(
+            CallingStatus.CONNECTED,
+            isRecording = true,
+            isTranscribing = false,
+        )
+        val expectedBannerInfoType: BannerInfoType = BannerInfoType.RECORDING_STARTED
+
+        runScopedTest {
+            // arrange
+            val initialCallingState = CallingState(CallingStatus.CONNECTED)
+            val bannerViewModel = BannerViewModel()
+            bannerViewModel.init(initialCallingState)
+
+            // act
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
+
+            // assert
+            Assert.assertEquals(expectedBannerInfoType, bannerViewModel.bannerInfoTypeStateFlow.value)
+            Assert.assertEquals(true, bannerViewModel.shouldShowBannerStateFlow.value)
+        }
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun bannerBarViewModel_update_when_recordingStateOFFTranscriptionStateOFFAndIsRecordingFalseIsTranscribingFalse_then_emitCorrectBannerInfoType_NOT_VISIBLE() {
+        val testCallingState = CallingState(
+            CallingStatus.CONNECTED,
+            isRecording = true,
+            isTranscribing = false,
+        )
+        val expectedBannerInfoType: BannerInfoType = BannerInfoType.RECORDING_STARTED
+
+        runScopedTest {
+            // arrange
+            val initialCallingState = CallingState(CallingStatus.CONNECTED)
+            val bannerViewModel = BannerViewModel()
+            bannerViewModel.init(initialCallingState)
+
+            // act
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.PIP_MODE_ENTERED))
+
+            // assert
+            Assert.assertEquals(expectedBannerInfoType, bannerViewModel.bannerInfoTypeStateFlow.value)
+            Assert.assertEquals(false, bannerViewModel.shouldShowBannerStateFlow.value)
+        }
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun bannerBarViewModel_update_when_recordingStateOFFTranscriptionStateOFFAndIsRecordingFalseIsTranscribingFalse_then_emitCorrectBannerInfoType_CHANGING_VISIBLE() {
+        val testCallingState = CallingState(
+            CallingStatus.CONNECTED,
+            isRecording = true,
+            isTranscribing = false,
+        )
+
+        runScopedTest {
+            // arrange
+            val initialCallingState = CallingState(CallingStatus.CONNECTED)
+            val bannerViewModel = BannerViewModel()
+            bannerViewModel.init(initialCallingState)
+
+            // act
+            bannerViewModel.update(
+                testCallingState,
+                VisibilityState(VisibilityStatus.PIP_MODE_ENTERED)
+            )
+
+            // assert
+            Assert.assertEquals(
+                BannerInfoType.RECORDING_STARTED,
+                bannerViewModel.bannerInfoTypeStateFlow.value
+            )
+            Assert.assertEquals(false, bannerViewModel.shouldShowBannerStateFlow.value)
+
+            // act
+            bannerViewModel.update(testCallingState, VisibilityState(VisibilityStatus.VISIBLE))
+
+            // assert
+            Assert.assertEquals(
+                BannerInfoType.RECORDING_STARTED,
+                bannerViewModel.bannerInfoTypeStateFlow.value
+            )
+            Assert.assertEquals(true, bannerViewModel.shouldShowBannerStateFlow.value)
+
+            // act
+            bannerViewModel.update(
+                CallingState(
+                    CallingStatus.CONNECTED,
+                    isRecording = false,
+                    isTranscribing = false,
+                ),
+                VisibilityState(VisibilityStatus.VISIBLE)
+            )
+
+            // assert
+            Assert.assertEquals(
+                BannerInfoType.RECORDING_STOPPED,
+                bannerViewModel.bannerInfoTypeStateFlow.value
+            )
+            Assert.assertEquals(true, bannerViewModel.shouldShowBannerStateFlow.value)
+
+            // act
+            bannerViewModel.update(
+                CallingState(
+                    CallingStatus.CONNECTED,
+                    isRecording = false,
+                    isTranscribing = false,
+                ),
+                VisibilityState(VisibilityStatus.PIP_MODE_ENTERED)
+            )
+
+            // assert
+            Assert.assertEquals(
+                BannerInfoType.RECORDING_STOPPED,
+                bannerViewModel.bannerInfoTypeStateFlow.value
+            )
+            Assert.assertEquals(false, bannerViewModel.shouldShowBannerStateFlow.value)
+
+            // act
+            bannerViewModel.update(
+                CallingState(
+                    CallingStatus.CONNECTED,
+                    isRecording = true,
+                    isTranscribing = true,
+                ),
+                VisibilityState(VisibilityStatus.PIP_MODE_ENTERED)
+            )
+
+            // assert
+            Assert.assertEquals(
+                BannerInfoType.RECORDING_AND_TRANSCRIPTION_STARTED,
+                bannerViewModel.bannerInfoTypeStateFlow.value
+            )
+            Assert.assertEquals(false, bannerViewModel.shouldShowBannerStateFlow.value)
+
+            // act
+            bannerViewModel.update(
+                CallingState(
+                    CallingStatus.CONNECTED,
+                    isRecording = true,
+                    isTranscribing = true,
+                ),
+                VisibilityState(VisibilityStatus.VISIBLE)
+            )
+
+            // assert
+            Assert.assertEquals(
+                BannerInfoType.RECORDING_AND_TRANSCRIPTION_STARTED,
+                bannerViewModel.bannerInfoTypeStateFlow.value
+            )
+            Assert.assertEquals(true, bannerViewModel.shouldShowBannerStateFlow.value)
         }
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Do not show Recording notification while in the Pip. Notification should be displayed when back to normal mode. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
