### PR TITLE
Resolve Chat Demo Crash

### DIFF
--- a/azure-communication-ui/demo-app/build.gradle
+++ b/azure-communication-ui/demo-app/build.gradle
@@ -192,7 +192,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.google.firebase:firebase-messaging:24.0.0'
 
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.0")
+    callingImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.0")
     androidTestImplementation('com.microsoft.appcenter:espresso-test-extension:1.4')
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     androidTestImplementation 'net.java.dev.jna:jna:5.10.0'


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Scoped "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.0" to calling, as it causes a runtime crash with xml when launching chat.

`2025-02-12 16:22:02.139 18119-18119 AndroidRuntime          com...callingcompositedemoapp.debug  E  FATAL EXCEPTION: main
                                                                                                    Process: com.azure.android.communication.ui.callingcompositedemoapp.debug, PID: 18119
                                                                                                    com.azure.android.communication.ui.chat.models.ChatCompositeException: App store exception while reducing state
                                                                                                    	at com.azure.android.communication.ui.chat.redux.AppStore$exceptionHandler$1$1.run(AppStore.kt:27)
                                                                                                    	at android.os.Handler.handleCallback(Handler.java:959)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:100)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:232)
                                                                                                    	at android.os.Looper.loop(Looper.java:317)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8705)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)
                                                                                                    Caused by: java.lang.NoSuchMethodError: No static method newFactory(Ljava/lang/String;Ljava/lang/ClassLoader;)Ljavax/xml/stream/XMLInputFactory; in class Ljavax/xml/stream/XMLInputFactory; or its super classes (declaration of 'javax.xml.stream.XMLInputFactory' appears in /data/app/~~qWNxvOzgzD4QW12t29YScQ==/com.azure.android.communication.ui.callingcompositedemoapp.debug-o88_WZFTDZ49NBlMgQRMUA==/base.apk!classes21.dex)
                                                                                                    	at com.fasterxml.jackson.dataformat.xml.XmlFactory.<init>(XmlFactory.java:115)
                                                                                                    	at com.fasterxml.jackson.dataformat.xml.XmlFactory.<init>(XmlFactory.java:101)
                                                                                                    	at com.fasterxml.jackson.dataformat.xml.XmlFactory.<init>(XmlFactory.java:85)
                                                                                                    	at com.fasterxml.jackson.dataformat.xml.XmlMapper.<init>(XmlMapper.java:127)
                                                                                                    	at com.azure.android.core.serde.jackson.JacksonSerder.<init>(JacksonSerder.java:96)
                                                                                                    	at com.azure.android.core.serde.jackson.JacksonSerder$JacksonSerderHolder.<clinit>(JacksonSerder.java:60)
                                                                                                    	at com.azure.android.core.serde.jackson.JacksonSerder.createDefault(JacksonSerder.java:70)
                                                                                                    	at com.azure.android.communication.chat.implementation.AzureCommunicationChatServiceImplBuilder.buildClient(AzureCommunicationChatServiceImplBuilder.java:163)
                                                                                                    	at com.azure.android.communication.chat.ChatClientBuilder.buildAsyncClient(ChatClientBuilder.java:236)
                                                                                                    	at com.azure.android.communication.chat.ChatClientBuilder.buildClient(ChatClientBuilder.java:178)`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [ ] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
