### PR TITLE
[Calling] Add captions received event to CallComposite

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/CallComposite.java
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/CallComposite.java
@@ -22,7 +22,9 @@ import com.azure.android.communication.ui.calling.logger.Logger;
 import com.azure.android.communication.ui.calling.models.CallCompositeAudioSelectionChangedEvent;
 import com.azure.android.communication.ui.calling.models.CallCompositeCallStateCode;
 import com.azure.android.communication.ui.calling.models.CallCompositeCallStateChangedEvent;
+/* <CAPTIONS_RECEIVED> */
 import com.azure.android.communication.ui.calling.models.CallCompositeCaptionsReceivedEvent;
+/* </CAPTIONS_RECEIVED> */
 import com.azure.android.communication.ui.calling.models.CallCompositeDebugInfo;
 import com.azure.android.communication.ui.calling.models.CallCompositeDismissedEvent;
 import com.azure.android.communication.ui.calling.models.CallCompositeErrorEvent;
@@ -674,6 +676,7 @@ public final class CallComposite {
         configuration.getCallCompositeEventsHandler().removeOnMultitaskingStateChangedEventHandler(eventHandler);
     }
 
+    /* <CAPTIONS_RECEIVED> */
     /**
      * Add on captions received event handler {@link CallCompositeEventHandler}.
      *
@@ -705,6 +708,7 @@ public final class CallComposite {
             final CallCompositeEventHandler<CallCompositeCaptionsReceivedEvent> handler) {
         configuration.getCallCompositeEventsHandler().removeOnCaptionsReceivedEventHandler(handler);
     }
+    /* </CAPTIONS_RECEIVED> */
 
     /**
      * Set {@link CallCompositeParticipantViewData}.

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/CallComposite.java
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/CallComposite.java
@@ -22,6 +22,7 @@ import com.azure.android.communication.ui.calling.logger.Logger;
 import com.azure.android.communication.ui.calling.models.CallCompositeAudioSelectionChangedEvent;
 import com.azure.android.communication.ui.calling.models.CallCompositeCallStateCode;
 import com.azure.android.communication.ui.calling.models.CallCompositeCallStateChangedEvent;
+import com.azure.android.communication.ui.calling.models.CallCompositeCaptionsReceivedEvent;
 import com.azure.android.communication.ui.calling.models.CallCompositeDebugInfo;
 import com.azure.android.communication.ui.calling.models.CallCompositeDismissedEvent;
 import com.azure.android.communication.ui.calling.models.CallCompositeErrorEvent;
@@ -671,6 +672,38 @@ public final class CallComposite {
     public void removeOnPictureInPictureChangedEventHandler(
             final CallCompositeEventHandler<CallCompositePictureInPictureChangedEvent> eventHandler) {
         configuration.getCallCompositeEventsHandler().removeOnMultitaskingStateChangedEventHandler(eventHandler);
+    }
+
+    /**
+     * Add on captions received event handler {@link CallCompositeEventHandler}.
+     *
+     * <pre>
+     *
+     * // add on captions received event handler
+     * callComposite.addOnCaptionsReceivedEventHandler(event -> {
+     *     // Process captions received event
+     *     System.out.println(event.getSpeakerName());
+     *     System.out.println(event.getCaptionText());
+     *     System.out.println(event.getIsFinal());
+     * });
+     *
+     * </pre>
+     *
+     * @param handler The {@link CallCompositeEventHandler}.
+     */
+    public void addOnCaptionsReceivedEventHandler(
+            final CallCompositeEventHandler<CallCompositeCaptionsReceivedEvent> handler) {
+        configuration.getCallCompositeEventsHandler().addOnCaptionsReceivedEventHandler(handler);
+    }
+
+    /**
+     * Remove on captions received event handler {@link CallCompositeEventHandler}.
+     *
+     * @param handler The {@link CallCompositeEventHandler}.
+     */
+    public void removeOnCaptionsReceivedEventHandler(
+            final CallCompositeEventHandler<CallCompositeCaptionsReceivedEvent> handler) {
+        configuration.getCallCompositeEventsHandler().removeOnCaptionsReceivedEventHandler(handler);
     }
 
     /**

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/configuration/events/CallCompositeEventsHandler.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/configuration/events/CallCompositeEventsHandler.kt
@@ -3,11 +3,13 @@
 
 package com.azure.android.communication.ui.calling.configuration.events
 
-/*  <CALL_START_TIME> */
+
 import com.azure.android.communication.ui.calling.CallCompositeEventHandler
 import com.azure.android.communication.ui.calling.models.CallCompositeAudioSelectionChangedEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeCallStateChangedEvent
+/* <CAPTIONS_RECEIVED> */
 import com.azure.android.communication.ui.calling.models.CallCompositeCaptionsReceivedEvent
+/* </CAPTIONS_RECEIVED> */
 import com.azure.android.communication.ui.calling.models.CallCompositeDismissedEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeErrorEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeIncomingCallCancelledEvent
@@ -16,8 +18,8 @@ import com.azure.android.communication.ui.calling.models.CallCompositePictureInP
 import com.azure.android.communication.ui.calling.models.CallCompositeRemoteParticipantJoinedEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeRemoteParticipantLeftEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeUserReportedIssueEvent
+/*  <CALL_START_TIME> */
 import java.util.Date
-
 /* </CALL_START_TIME> */
 
 internal class CallCompositeEventsHandler {
@@ -52,7 +54,9 @@ internal class CallCompositeEventsHandler {
         mutableSetOf<CallCompositeEventHandler<Date>>()
     /* </CALL_START_TIME> */
 
+    /* <CAPTIONS_RECEIVED> */
     private val onCaptionsReceivedHandlers = mutableSetOf<CallCompositeEventHandler<CallCompositeCaptionsReceivedEvent>>()
+    /* </CAPTIONS_RECEIVED> */
 
     fun getOnErrorHandlers() = errorHandlers.asIterable()
 
@@ -150,6 +154,7 @@ internal class CallCompositeEventsHandler {
     }
     /* </CALL_START_TIME> */
 
+    /* <CAPTIONS_RECEIVED> */
     fun addOnCaptionsReceivedEventHandler(handler: CallCompositeEventHandler<CallCompositeCaptionsReceivedEvent>) {
         onCaptionsReceivedHandlers.add(handler)
     }
@@ -159,4 +164,5 @@ internal class CallCompositeEventsHandler {
     }
 
     internal fun getCaptionsReceivedEventHandlers() = onCaptionsReceivedHandlers.asIterable()
+    /* </CAPTIONS_RECEIVED> */
 }

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/configuration/events/CallCompositeEventsHandler.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/configuration/events/CallCompositeEventsHandler.kt
@@ -3,19 +3,21 @@
 
 package com.azure.android.communication.ui.calling.configuration.events
 
+/*  <CALL_START_TIME> */
 import com.azure.android.communication.ui.calling.CallCompositeEventHandler
-import com.azure.android.communication.ui.calling.models.CallCompositeCallStateChangedEvent
-import com.azure.android.communication.ui.calling.models.CallCompositeErrorEvent
-import com.azure.android.communication.ui.calling.models.CallCompositePictureInPictureChangedEvent
-import com.azure.android.communication.ui.calling.models.CallCompositeDismissedEvent
-import com.azure.android.communication.ui.calling.models.CallCompositeRemoteParticipantJoinedEvent
-import com.azure.android.communication.ui.calling.models.CallCompositeUserReportedIssueEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeAudioSelectionChangedEvent
+import com.azure.android.communication.ui.calling.models.CallCompositeCallStateChangedEvent
+import com.azure.android.communication.ui.calling.models.CallCompositeCaptionsReceivedEvent
+import com.azure.android.communication.ui.calling.models.CallCompositeDismissedEvent
+import com.azure.android.communication.ui.calling.models.CallCompositeErrorEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeIncomingCallCancelledEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeIncomingCallEvent
+import com.azure.android.communication.ui.calling.models.CallCompositePictureInPictureChangedEvent
+import com.azure.android.communication.ui.calling.models.CallCompositeRemoteParticipantJoinedEvent
 import com.azure.android.communication.ui.calling.models.CallCompositeRemoteParticipantLeftEvent
-/*  <CALL_START_TIME> */
+import com.azure.android.communication.ui.calling.models.CallCompositeUserReportedIssueEvent
 import java.util.Date
+
 /* </CALL_START_TIME> */
 
 internal class CallCompositeEventsHandler {
@@ -49,6 +51,8 @@ internal class CallCompositeEventsHandler {
     private val callStartTimeUpdatedEventHandlers =
         mutableSetOf<CallCompositeEventHandler<Date>>()
     /* </CALL_START_TIME> */
+
+    private val onCaptionsReceivedHandlers = mutableSetOf<CallCompositeEventHandler<CallCompositeCaptionsReceivedEvent>>()
 
     fun getOnErrorHandlers() = errorHandlers.asIterable()
 
@@ -145,4 +149,14 @@ internal class CallCompositeEventsHandler {
         callStartTimeUpdatedEventHandlers.remove(eventHandler)
     }
     /* </CALL_START_TIME> */
+
+    fun addOnCaptionsReceivedEventHandler(handler: CallCompositeEventHandler<CallCompositeCaptionsReceivedEvent>) {
+        onCaptionsReceivedHandlers.add(handler)
+    }
+
+    fun removeOnCaptionsReceivedEventHandler(handler: CallCompositeEventHandler<CallCompositeCaptionsReceivedEvent>) {
+        onCaptionsReceivedHandlers.remove(handler)
+    }
+
+    internal fun getCaptionsReceivedEventHandlers() = onCaptionsReceivedHandlers.asIterable()
 }

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/di/DependencyInjectionContainerImpl.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/di/DependencyInjectionContainerImpl.kt
@@ -94,6 +94,7 @@ internal class DependencyInjectionContainerImpl(
 
     override val captionsRttDataManager by lazy {
         CaptionsRttDataManager(
+            configuration,
             callingService,
             appStore,
             avatarViewManager,

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/di/DependencyInjectionContainerImpl.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/di/DependencyInjectionContainerImpl.kt
@@ -94,7 +94,9 @@ internal class DependencyInjectionContainerImpl(
 
     override val captionsRttDataManager by lazy {
         CaptionsRttDataManager(
+            /* <CAPTIONS_RECEIVED> */
             configuration,
+            /* </CAPTIONS_RECEIVED> */
             callingService,
             appStore,
             avatarViewManager,

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeCaptionsReceivedEvent.java
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeCaptionsReceivedEvent.java
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.communication.ui.calling.models;
+
+/**
+ * Call composite captions received event.
+ */
+public class CallCompositeCaptionsReceivedEvent {
+    private final String speakerName;
+    private final String speakerRawId;
+    private final String captionText;
+    private final String languageCode;
+
+    CallCompositeCaptionsReceivedEvent(
+            final String speakerName,
+            final String speakerRawId,
+            final String captionText,
+            final String languageCode) {
+        this.speakerName = speakerName;
+        this.speakerRawId = speakerRawId;
+        this.captionText = captionText;
+        this.languageCode = languageCode;
+    }
+
+    /**
+     * Get speaker name.
+     * @return Speaker name
+     */
+    public String getSpeakerName() { return speakerName; }
+
+    /**
+     * Get speaker raw id.
+     * @return Speaker raw id
+     */
+    public String getSpeakerRawId() { return speakerRawId; }
+
+    /**
+     * Get caption text.
+     * @return Caption text
+     */
+    public String getCaptionText() { return captionText; }
+
+    /**
+     * Get language code.
+     * @return Language code
+     */
+    public String getLanguageCode() { return languageCode; }
+}

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeCaptionsReceivedEvent.java
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeCaptionsReceivedEvent.java
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
+/* <CAPTIONS_RECEIVED> */
 package com.azure.android.communication.ui.calling.models;
 
 /**
@@ -47,3 +47,4 @@ public class CallCompositeCaptionsReceivedEvent {
      */
     public String getLanguageCode() { return languageCode; }
 }
+/* </CAPTIONS_RECEIVED> */

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeExtensions.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeExtensions.kt
@@ -60,7 +60,7 @@ internal fun CallCompositeButtonViewData.setVisibleChangedEventHandler(handler: 
     this.visibleChangedEventHandler = handler
 }
 
-
+/* <CAPTIONS_RECEIVED> */
 internal fun createCallCompositeCaptionsReceivedEvent(
     speakerName: String,
     speakerRawId: String,
@@ -74,4 +74,4 @@ internal fun createCallCompositeCaptionsReceivedEvent(
         languageCode
     )
 }
-
+/* </CAPTIONS_RECEIVED> */

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeExtensions.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/models/CallCompositeExtensions.kt
@@ -59,3 +59,19 @@ internal fun CallCompositeButtonViewData.setEnabledChangedEventHandler(handler: 
 internal fun CallCompositeButtonViewData.setVisibleChangedEventHandler(handler: CallCompositeEventHandler<Boolean>) {
     this.visibleChangedEventHandler = handler
 }
+
+
+internal fun createCallCompositeCaptionsReceivedEvent(
+    speakerName: String,
+    speakerRawId: String,
+    captionText: String,
+    languageCode: String,
+): CallCompositeCaptionsReceivedEvent {
+    return CallCompositeCaptionsReceivedEvent(
+        speakerName,
+        speakerRawId,
+        captionText,
+        languageCode
+    )
+}
+

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/manager/CaptionsRttDataManager.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/manager/CaptionsRttDataManager.kt
@@ -5,11 +5,15 @@ package com.azure.android.communication.ui.calling.presentation.manager
 
 import android.graphics.Bitmap
 import com.azure.android.communication.common.CommunicationIdentifier
+/* <CAPTIONS_RECEIVED> */
 import com.azure.android.communication.ui.calling.configuration.CallCompositeConfiguration
+/* </CAPTIONS_RECEIVED> */
 import com.azure.android.communication.ui.calling.models.CallCompositeCaptionsData
 import com.azure.android.communication.ui.calling.models.CaptionsResultType
 import com.azure.android.communication.ui.calling.models.RttMessage
+/* <CAPTIONS_RECEIVED> */
 import com.azure.android.communication.ui.calling.models.createCallCompositeCaptionsReceivedEvent
+/* </CAPTIONS_RECEIVED> */
 import com.azure.android.communication.ui.calling.presentation.fragment.calling.CallingFragment
 import com.azure.android.communication.ui.calling.presentation.fragment.calling.captions.CaptionsRttRecord
 import com.azure.android.communication.ui.calling.presentation.fragment.calling.captions.CaptionsRttType
@@ -34,7 +38,9 @@ import java.util.Date
 import kotlin.math.min
 
 internal class CaptionsRttDataManager(
+    /* <CAPTIONS_RECEIVED> */
     private val configuration: CallCompositeConfiguration,
+    /* </CAPTIONS_RECEIVED> */
     private val callingService: CallingService,
     private val appStore: AppStore<ReduxState>,
     private val avatarViewManager: AvatarViewManager,
@@ -229,7 +235,9 @@ internal class CaptionsRttDataManager(
 
         if (lastCaptionFromSameUser != null && shouldFinalizeLastCaption(lastCaptionFromSameUser, newCaptionsRecord)) {
             lastCaptionFromSameUser = finalizeLastCaption(lastCaptionFromSameUser)
+            /* <CAPTIONS_RECEIVED> */
             notifyCaptionReceived(lastCaptionFromSameUser)
+            /* </CAPTIONS_RECEIVED> */
         }
 
         if (lastCaptionFromSameUser?.isFinal == false) {
@@ -238,11 +246,14 @@ internal class CaptionsRttDataManager(
             addNewCaption(newCaptionsRecord)
         }
 
+        /* <CAPTIONS_RECEIVED> */
         if (newCaptionsRecord.isFinal) {
             notifyCaptionReceived(newCaptionsRecord)
         }
+        /* </CAPTIONS_RECEIVED> */
     }
 
+    /* <CAPTIONS_RECEIVED> */
     private fun notifyCaptionReceived(finalizedCaptionsRecord: CaptionsRttRecord) {
         val event = createCallCompositeCaptionsReceivedEvent(
             finalizedCaptionsRecord.displayName ?: "",
@@ -256,6 +267,7 @@ internal class CaptionsRttDataManager(
                 handler.handle(event)
             }
     }
+    /* </CAPTIONS_RECEIVED> */
 
     private fun getLastCaptionFromUser(speakerRawId: String?, type: CaptionsRttType): CaptionsRttRecord? {
         return captionsAndRttMutableList.lastOrNull { it.type == type && it.speakerRawId == speakerRawId }

--- a/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/CallCompositeManager.kt
+++ b/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/CallCompositeManager.kt
@@ -378,12 +378,14 @@ class CallCompositeManager(private val context: Context) {
             )
         }
 
+        /* <CAPTIONS_RECEIVED> */
         callComposite.addOnCaptionsReceivedEventHandler {
             toast(
                 context,
                 "Captions received: speakerName: ${it.speakerName}, speakerRawId: ${it.speakerRawId}, captionText: ${it.captionText}, languageCode: ${it.languageCode}"
             )
         }
+        /* </CAPTIONS_RECEIVED> */
     }
 
     fun dismissCallComposite() {

--- a/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/CallCompositeManager.kt
+++ b/azure-communication-ui/demo-app/src/calling/java/com/azure/android/communication/ui/callingcompositedemoapp/CallCompositeManager.kt
@@ -377,6 +377,13 @@ class CallCompositeManager(private val context: Context) {
                 RemoteParticipantJoinedHandler(callComposite, context)
             )
         }
+
+        callComposite.addOnCaptionsReceivedEventHandler {
+            toast(
+                context,
+                "Captions received: speakerName: ${it.speakerName}, speakerRawId: ${it.speakerRawId}, captionText: ${it.captionText}, languageCode: ${it.languageCode}"
+            )
+        }
     }
 
     fun dismissCallComposite() {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Introduces CallCompositeCaptionsReceivedEvent and related event handler registration methods to CallComposite. Updates dependency injection and CaptionsRttDataManager to trigger the event when captions are finalized. Demo app now displays a toast when captions are received.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull Request Checklist

<!-- Please check that applies to this PR using "x". -->

- [x] Public API changes
- [ ] Verified for cross-platform
- [ ] Synced with iOS, Web team
- [ ] Internal review completed
- [ ] UI Changes
  - [ ] Screen captures included
  - [ ] Tested for Light/Dark mode
  - [ ] Tested for screen rotation
  - [ ] Tested on Tablet and small screen device (5")
  - [ ] Include localization changes
- [ ] Tests
  - [ ] Memory leak analysis performed
  - [ ] Tested on API 21, 26 and latest 
  - [ ] Tested for background mode
  - [ ] Unit Tests Included
  - [ ] UI Automated Tests Included

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
